### PR TITLE
Adding support for PLIC priority threshold register

### DIFF
--- a/src/Emulator/Cores/RiscV/PLIC/IrqContext.cs
+++ b/src/Emulator/Cores/RiscV/PLIC/IrqContext.cs
@@ -18,8 +18,7 @@ namespace Antmicro.Renode.Peripherals.IRQControllers.PLIC
         {
             this.irqController = irqController;
             this.id = id;
-            this.priorityThreshold = 0; //need to change?
-
+            this.priorityThreshold = 0;
 
             enabledSources = new HashSet<IrqSource>();
             activeInterrupts = new Stack<IrqSource>();
@@ -48,10 +47,7 @@ namespace Antmicro.Renode.Peripherals.IRQControllers.PLIC
             }
 
             var currentPriority = activeInterrupts.Count > 0 ? activeInterrupts.Peek().Priority : 0; 
-
             var isPending = enabledSources.Any(x => x.Priority > currentPriority && x.IsPending);
-
-            //irqController.Log(LogLevel.Info, "IrqContext.cs: RefreshInterrupt(): currentPriority {0} isPending = {1}", currentPriority, isPending);
             irqController.Connections[(int)this.id].Set(isPending);
         }
 
@@ -119,12 +115,9 @@ namespace Antmicro.Renode.Peripherals.IRQControllers.PLIC
             }
             else
             {
-                //returns the highest-priority, pending Irq from enabled Sources. If there is a tie in priority, lowest ID returned first:
                 pendingIrq = enabledSources.Where(x => x.IsPending)
                     .OrderByDescending(x => x.Priority)
                     .ThenBy(x => x.Id).FirstOrDefault(); 
-
-                irqController.Log(LogLevel.Noisy, "IrqContext.cs: AcknowledgePendingInterrupt(): pendingIrq {0}", pendingIrq);
             }
 
             if(pendingIrq == null)
@@ -142,12 +135,11 @@ namespace Antmicro.Renode.Peripherals.IRQControllers.PLIC
                 return pendingIrq.Id;
             }
             else{
-                irqController.Log(LogLevel.Info, "Not acknowledging pending interrupt #{0} @ {1} since priorityThreshold = {2} > priority = {3}",
+                irqController.Log(LogLevel.Info, "Ignore pending interrupt #{0} @ {1} (priorityThreshold = {2} > priority = {3})",
                  pendingIrq.Id, this, this.priorityThreshold, pendingIrq.Priority);
                 RefreshInterrupt();
                 return 0;
             }
-
             
         }
 

--- a/src/Emulator/Cores/RiscV/PLIC/IrqContext.cs
+++ b/src/Emulator/Cores/RiscV/PLIC/IrqContext.cs
@@ -18,6 +18,8 @@ namespace Antmicro.Renode.Peripherals.IRQControllers.PLIC
         {
             this.irqController = irqController;
             this.id = id;
+            this.priorityThreshold = 0; //need to change?
+
 
             enabledSources = new HashSet<IrqSource>();
             activeInterrupts = new Stack<IrqSource>();
@@ -45,14 +47,17 @@ namespace Antmicro.Renode.Peripherals.IRQControllers.PLIC
                 return;
             }
 
-            var currentPriority = activeInterrupts.Count > 0 ? activeInterrupts.Peek().Priority : 0;
+            var currentPriority = activeInterrupts.Count > 0 ? activeInterrupts.Peek().Priority : 0; 
+
             var isPending = enabledSources.Any(x => x.Priority > currentPriority && x.IsPending);
+
+            //irqController.Log(LogLevel.Info, "IrqContext.cs: RefreshInterrupt(): currentPriority {0} isPending = {1}", currentPriority, isPending);
             irqController.Connections[(int)this.id].Set(isPending);
         }
 
         public void CompleteHandlingInterrupt(IrqSource irq)
         {
-            irqController.Log(LogLevel.Noisy, "Completing irq {0} at {1}", irq.Id, this);
+            irqController.Log(LogLevel.Info, "Completing irq {0} at {1}", irq.Id, this);
 
             if(activeInterrupts.Count == 0)
             {
@@ -84,6 +89,25 @@ namespace Antmicro.Renode.Peripherals.IRQControllers.PLIC
             RefreshInterrupt();
         }
 
+        public ulong PriorityThreshold
+        {
+            get 
+            { 
+                irqController.Log(LogLevel.Info, "Read priority threshold {0} for context #{1}", priorityThreshold, id);
+                return priorityThreshold; 
+            }
+             set
+             {
+                if(value == priorityThreshold)
+                {
+                 return;
+                }
+
+                irqController.Log(LogLevel.Info, "Setting priority threshold to {0} for context #{1}", value, id);
+                priorityThreshold = value;
+             }
+        }
+
         public uint AcknowledgePendingInterrupt()
         {
             IrqSource pendingIrq;
@@ -95,27 +119,43 @@ namespace Antmicro.Renode.Peripherals.IRQControllers.PLIC
             }
             else
             {
+                //returns the highest-priority, pending Irq from enabled Sources. If there is a tie in priority, lowest ID returned first:
                 pendingIrq = enabledSources.Where(x => x.IsPending)
                     .OrderByDescending(x => x.Priority)
-                    .ThenBy(x => x.Id).FirstOrDefault();
+                    .ThenBy(x => x.Id).FirstOrDefault(); 
+
+                irqController.Log(LogLevel.Noisy, "IrqContext.cs: AcknowledgePendingInterrupt(): pendingIrq {0}", pendingIrq);
             }
 
             if(pendingIrq == null)
             {
-                irqController.Log(LogLevel.Noisy, "There is no pending interrupt to acknowledge at the moment for {0}. Currently enabled sources: {1}", this, string.Join(", ", enabledSources.Select(x => x.ToString())));
+                irqController.Log(LogLevel.Warning, "There is no pending interrupt to acknowledge at the moment for {0}. Currently enabled sources: {1}", this, string.Join(", ", enabledSources.Select(x => x.ToString())));
                 return 0;
             }
             pendingIrq.IsPending = false;
-            activeInterrupts.Push(pendingIrq);
 
-            irqController.Log(LogLevel.Noisy, "Acknowledging pending interrupt #{0} @ {1}", pendingIrq.Id, this);
+            //support for priority threshold here
+            if (pendingIrq.Priority >= this.priorityThreshold){ 
+                activeInterrupts.Push(pendingIrq);
+                irqController.Log(LogLevel.Info, "Acknowledging pending interrupt #{0} @ {1}", pendingIrq.Id, this);
+                RefreshInterrupt();
+                return pendingIrq.Id;
+            }
+            else{
+                irqController.Log(LogLevel.Info, "Not acknowledging pending interrupt #{0} @ {1} since priorityThreshold = {2} > priority = {3}",
+                 pendingIrq.Id, this, this.priorityThreshold, pendingIrq.Priority);
+                RefreshInterrupt();
+                return 0;
+            }
 
-            RefreshInterrupt();
-            return pendingIrq.Id;
+            
         }
+
+        private ulong priorityThreshold;
 
         private readonly uint id;
         private readonly IPlatformLevelInterruptController irqController;
+
         private readonly HashSet<IrqSource> enabledSources;
         private readonly Stack<IrqSource> activeInterrupts;
     }

--- a/src/Emulator/Cores/RiscV/PLIC/PlatformLevelInterruptControllerBase.cs
+++ b/src/Emulator/Cores/RiscV/PLIC/PlatformLevelInterruptControllerBase.cs
@@ -44,7 +44,6 @@ namespace Antmicro.Renode.Peripherals.IRQControllers.PLIC
 
         public uint ReadDoubleWord(long offset)
         {
-            //Console.WriteLine("Debugging, PLICbase.cs: ReadDoubleWord(): offset = 0x{0:x8}", offset); //debugging
             return registers.Read(offset);
         }
 
@@ -67,7 +66,6 @@ namespace Antmicro.Renode.Peripherals.IRQControllers.PLIC
         public void WriteDoubleWord(long offset, uint value)
         {
             registers.Write(offset, value);
-            //Console.WriteLine("Debugging, PLICbase.cs: WriteDoubleWord(): offset = 0x{0:x8}, value = 0x{1:x8}", offset, value); //debugging
         }
 
         public void OnGPIO(int number, bool value)
@@ -110,7 +108,6 @@ namespace Antmicro.Renode.Peripherals.IRQControllers.PLIC
 
         protected void AddContextClaimCompleteRegister(Dictionary<long, DoubleWordRegister> registersMap, long offset, uint contextId)
         {
-            //Console.WriteLine("Debugging, AddContextClaimCompleteRegister(): offset = 0x{0:x8}, contextID = {1}", offset, contextId); //debugging
             registersMap.Add(offset, new DoubleWordRegister(this).WithValueField(0, 32, valueProviderCallback: _ =>
             {
                 lock(irqSources)
@@ -138,7 +135,6 @@ namespace Antmicro.Renode.Peripherals.IRQControllers.PLIC
         protected void AddContextEnablesRegister(Dictionary<long, DoubleWordRegister> registersMap, long address, uint contextId, int numberOfSources)
         {
             var maximumSourceDoubleWords = (int)Math.Ceiling((numberOfSources + 1) / 32.0) * 4;
-            //Console.WriteLine("Debugging, AddContextEnablesRegister(): maximumSourceDoubleWords = 0x{0:x8}, address = 0x{1:x8}, contextID = {2}", maximumSourceDoubleWords, address, contextId); //debugging
             for(var offset = 0u; offset < maximumSourceDoubleWords; offset += 4)
             {
                 var lOffset = offset;
@@ -174,8 +170,7 @@ namespace Antmicro.Renode.Peripherals.IRQControllers.PLIC
         //adapted from OpenTitan_PlatformLevelInterruptController.cs
         protected void AddContextPriorityThresholdRegisterPLIC(Dictionary<long, DoubleWordRegister> registersMap, long offset, uint contextId)
         {
-            //Console.WriteLine("Debugging, AddContextPriorityThresholdRegister(): offset = 0x{0:x8}, contextID = {1}", offset, contextId); //debugging
-            this.Log(LogLevel.Noisy, "Adding Context {0} threshold priority register address 0x{1:X}", contextId, offset);
+            this.Log(LogLevel.Noisy, "Adding Context {0} priority threshold register @ address 0x{1:X}", contextId, offset);
             registersMap.Add(offset, new DoubleWordRegister(this).WithValueField(0, 32, valueProviderCallback: _ =>
                     {
                         lock(irqSources)

--- a/src/Emulator/Cores/RiscV/PlatformLevelInterruptController.cs
+++ b/src/Emulator/Cores/RiscV/PlatformLevelInterruptController.cs
@@ -60,6 +60,7 @@ namespace Antmicro.Renode.Peripherals.IRQControllers
             {
                 AddContextEnablesRegister(registersMap, (long)Registers.Context0Enables + i * ContextEnablesWidth, i, numberOfSources);
                 AddContextClaimCompleteRegister(registersMap, (long)Registers.Context0ClaimComplete + i * ContextClaimWidth, i);
+                AddContextPriorityThresholdRegisterPLIC(registersMap, (long)Registers.Context0PriorityThreshold + i * ContextPriorityThresholdWidth, i);
             }
 
             registers = new DoubleWordRegisterCollection(this, registersMap);
@@ -87,8 +88,10 @@ namespace Antmicro.Renode.Peripherals.IRQControllers
             Context0PriorityThreshold = 0x200000,
             Context0ClaimComplete = 0x200004,
             // ...
-            Context1PriorityThreshold = 0x201000,
-            Context1ClaimComplete = 0x201004,
+            //Context1PriorityThreshold = 0x201000,
+            Context1PriorityThreshold = 0x200088,
+            //Context1ClaimComplete = 0x201004,
+            Context1ClaimComplete = 0x20008C,
             // ...
             Context2PriorityThreshold = 0x202000,
             Context2ClaimComplete = 0x202004,
@@ -101,6 +104,7 @@ namespace Antmicro.Renode.Peripherals.IRQControllers
             // ...
         }
 
+        private const long ContextPriorityThresholdWidth = Registers.Context1PriorityThreshold - Registers.Context0PriorityThreshold;
         private const long ContextEnablesWidth = Registers.Context1Enables - Registers.Context0Enables;
         private const long ContextClaimWidth = Registers.Context1ClaimComplete - Registers.Context0ClaimComplete;
         private const uint MaxSources = (uint)(ContextEnablesWidth / 4) * 32;


### PR DESCRIPTION
### **Summary**
- Adding support to be able to read/write to priority threshold register such that a certain interrupt will only be executed if a source's priority >= a context's priority threshold.
- Changes made to src/Infrastructure/src/Emulator/Cores/RiscV/PLIC/PlatformLevelInterruptControllerBase.cs include function AddContextPriorityThresholdRegisterPLIC() to create priority threshold registers and support read/write abilities. 
- Changes made to src/Infrastructure/src/Emulator/Cores/RiscV/PLIC/IrqContext.cs include creating variable for priority threshold, getter/setter function, and functionality for comparing source's priority to context's priority threshold in AcknowledgePendingInterrupt(). In default constructor, set this.priorityThreshold to 0 (ie capture interrupts of all priorities).
- Changes made to src/Infrastructure/src/Emulator/Cores/RiscV/PlatformLevelInterruptController.cs include creation of priority threshold registers for each context by calling AddContextPriorityThresholdRegisterPLIC() for each context. Also changed addresses of some registers to match those in Gemini code.

### **Testing**
- Tested with a sample program using UART interrupt from ATCUART100 peripheral: 
- The priority threshold of the context and priority of the UART interrupt were testing by changing variables in gemini_interrupt.c. 
- Set PLIC_REGS->properties_context[0].priority_threshold in subsystem_enable_interrupts() to set priority register for context 0. 
- Set PLIC_REGS->priority[irq_source - 18] in irq_map_unmask_and_enable_in_controller() to set priority of UART source.

-  UART will print an ISR message if interrupt is taken, along with corresponding log messages:

![image](https://github.com/RapidSilicon/renode-infrastructure_rs/assets/133986296/f17aa8ac-a9f0-4917-adf0-17f421b39718)

- If UART interrupt is not taken, test program will continue as usual and corresponding log messages will give details:

![image](https://github.com/RapidSilicon/renode-infrastructure_rs/assets/133986296/41a6fd8c-8f3c-4441-b2fd-a41abad08114)

