### PR TITLE
Add ATCPIT100

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,5 @@
 [submodule "src/Emulator/Cores/tlib"]
 	path = src/Emulator/Cores/tlib
 	url = https://github.com/antmicro/tlib.git
+[submodule "src/Infrastructure"]
+	branch = add_atcpit

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,3 @@
 [submodule "src/Emulator/Cores/tlib"]
 	path = src/Emulator/Cores/tlib
 	url = https://github.com/antmicro/tlib.git
-[submodule "src/Infrastructure"]
-	branch = add_atcpit

--- a/src/Emulator/Main/Peripherals/Timers/ComparingTimer.cs
+++ b/src/Emulator/Main/Peripherals/Timers/ComparingTimer.cs
@@ -49,7 +49,7 @@ namespace Antmicro.Renode.Peripherals.Timers
             this.owner = this is IPeripheral && owner == null ? this : owner;
             this.localName = localName;
             InternalReset();
-            this.Log(LogLevel.Info, "Creating ComparingTimers with freq: {0}, limit: 0x{1:X}, compare: {2:X}, clockSource: {3}, workMode: {4}", frequency, limit, compare, clockSource, workMode);
+            //this.Log(LogLevel.Info, "Creating ComparingTimers with freq: {0}, limit: 0x{1:X}, compare: {2:X}, clockSource: {3}, workMode: {4}", frequency, limit, compare, clockSource, workMode);
         }
 
         protected ComparingTimer(IClockSource clockSource, long frequency, ulong limit = ulong.MaxValue, Direction direction = Direction.Ascending, bool enabled = false, WorkMode workMode = WorkMode.OneShot, bool eventEnabled = false, ulong compare = ulong.MaxValue, uint divider = 1, uint step = 1) 
@@ -67,7 +67,7 @@ namespace Antmicro.Renode.Peripherals.Timers
             {
                 
                 clockSource.ExchangeClockEntryWith(CompareReachedInternal, oldEntry => oldEntry.With(enabled: value));
-                this.Log(LogLevel.Info, "Setting ComparingTimers enabled to: {0}", value);
+                //this.Log(LogLevel.Info, "Setting ComparingTimers enabled to: {0}", value);
             }
         }
 
@@ -99,7 +99,7 @@ namespace Antmicro.Renode.Peripherals.Timers
                 {
                     currentValue = valueAccumulatedSoFar + entry.Value;
                 });
-                this.Log(LogLevel.Info, "ComparingTimers value: {0}", currentValue);
+                //this.Log(LogLevel.Info, "ComparingTimers value: {0}", currentValue);
                 return currentValue;
             }
             set
@@ -112,7 +112,7 @@ namespace Antmicro.Renode.Peripherals.Timers
                 clockSource.ExchangeClockEntryWith(CompareReachedInternal, entry =>
                 {
                     valueAccumulatedSoFar = value;
-                    this.Log(LogLevel.Info, "ComparingTimers value: 0x{0:X}", value);
+                    //this.Log(LogLevel.Info, "ComparingTimers value: 0x{0:X}", value);
                     return entry.With(period: CalculatePeriod(), value: 0);
                 });
             }
@@ -134,7 +134,7 @@ namespace Antmicro.Renode.Peripherals.Timers
                 {
                     compareValue = value;
                     valueAccumulatedSoFar += entry.Value;
-                    this.Log(LogLevel.Info, "ComparingTimer compare value: 0x{0:X} , valueAccumulatedSoFar: 0x{1:X}", value, valueAccumulatedSoFar);
+                    //this.Log(LogLevel.Info, "ComparingTimer compare value: 0x{0:X} , valueAccumulatedSoFar: 0x{1:X}", value, valueAccumulatedSoFar);
                     return entry.With(period: CalculatePeriod(), value: 0);
                 });
             }
@@ -191,7 +191,7 @@ namespace Antmicro.Renode.Peripherals.Timers
             {
                 return;
             }
-            this.Log(LogLevel.Info, "ComparingTimers: reaching CompareReached");
+            //this.Log(LogLevel.Info, "ComparingTimers: reaching CompareReached");
 
             CompareReached?.Invoke();
         }
@@ -211,7 +211,7 @@ namespace Antmicro.Renode.Peripherals.Timers
         {
             // since we use OneShot, timer's value is already 0 and it is disabled now
             // first we add old limit to accumulated value:
-            this.Log(LogLevel.Info, "Reaching CompareReachedInternal");
+            //this.Log(LogLevel.Info, "Reaching CompareReachedInternal");
             valueAccumulatedSoFar += clockSource.GetClockEntry(CompareReachedInternal).Period;
             if(valueAccumulatedSoFar >= initialLimit && compareValue != initialLimit)
             {

--- a/src/Emulator/Main/Peripherals/Timers/ComparingTimer.cs
+++ b/src/Emulator/Main/Peripherals/Timers/ComparingTimer.cs
@@ -10,6 +10,7 @@ using Antmicro.Renode.Core;
 using Antmicro.Renode.Time;
 using Antmicro.Renode.Exceptions;
 using Antmicro.Renode.Utilities;
+using Antmicro.Renode.Logging;
 
 namespace Antmicro.Renode.Peripherals.Timers
 {
@@ -48,6 +49,7 @@ namespace Antmicro.Renode.Peripherals.Timers
             this.owner = this is IPeripheral && owner == null ? this : owner;
             this.localName = localName;
             InternalReset();
+            this.Log(LogLevel.Info, "Creating ComparingTimers with freq: {0}, limit: 0x{1:X}, compare: {2}", frequency, limit, compare);
         }
 
         protected ComparingTimer(IClockSource clockSource, long frequency, ulong limit = ulong.MaxValue, Direction direction = Direction.Ascending, bool enabled = false, WorkMode workMode = WorkMode.OneShot, bool eventEnabled = false, ulong compare = ulong.MaxValue, uint divider = 1, uint step = 1) 
@@ -95,6 +97,7 @@ namespace Antmicro.Renode.Peripherals.Timers
                 {
                     currentValue = valueAccumulatedSoFar + entry.Value;
                 });
+                this.Log(LogLevel.Info, "ComparingTimers value: {0}", currentValue);
                 return currentValue;
             }
             set
@@ -107,6 +110,7 @@ namespace Antmicro.Renode.Peripherals.Timers
                 clockSource.ExchangeClockEntryWith(CompareReachedInternal, entry =>
                 {
                     valueAccumulatedSoFar = value;
+                    this.Log(LogLevel.Info, "ComparingTimers value: 0x{0:X}", value);
                     return entry.With(period: CalculatePeriod(), value: 0);
                 });
             }
@@ -128,6 +132,7 @@ namespace Antmicro.Renode.Peripherals.Timers
                 {
                     compareValue = value;
                     valueAccumulatedSoFar += entry.Value;
+                    this.Log(LogLevel.Info, "ComparingTimer compare value: 0x{0:X} , valueAccumulatedSoFar: 0x{1:X}", value, valueAccumulatedSoFar);
                     return entry.With(period: CalculatePeriod(), value: 0);
                 });
             }
@@ -184,6 +189,7 @@ namespace Antmicro.Renode.Peripherals.Timers
             {
                 return;
             }
+            this.Log(LogLevel.Info, "ComparingTimers: reaching CompareReacehd");
 
             CompareReached?.Invoke();
         }

--- a/src/Emulator/Main/Peripherals/Timers/ComparingTimer.cs
+++ b/src/Emulator/Main/Peripherals/Timers/ComparingTimer.cs
@@ -49,7 +49,7 @@ namespace Antmicro.Renode.Peripherals.Timers
             this.owner = this is IPeripheral && owner == null ? this : owner;
             this.localName = localName;
             InternalReset();
-            this.Log(LogLevel.Info, "Creating ComparingTimers with freq: {0}, limit: 0x{1:X}, compare: {2}, clockSource: {3}, workMode: {4}", frequency, limit, compare, clockSource, workMode);
+            this.Log(LogLevel.Info, "Creating ComparingTimers with freq: {0}, limit: 0x{1:X}, compare: {2:X}, clockSource: {3}, workMode: {4}", frequency, limit, compare, clockSource, workMode);
         }
 
         protected ComparingTimer(IClockSource clockSource, long frequency, ulong limit = ulong.MaxValue, Direction direction = Direction.Ascending, bool enabled = false, WorkMode workMode = WorkMode.OneShot, bool eventEnabled = false, ulong compare = ulong.MaxValue, uint divider = 1, uint step = 1) 

--- a/src/Emulator/Main/Peripherals/Timers/ComparingTimer.cs
+++ b/src/Emulator/Main/Peripherals/Timers/ComparingTimer.cs
@@ -49,7 +49,7 @@ namespace Antmicro.Renode.Peripherals.Timers
             this.owner = this is IPeripheral && owner == null ? this : owner;
             this.localName = localName;
             InternalReset();
-            this.Log(LogLevel.Info, "Creating ComparingTimers with freq: {0}, limit: 0x{1:X}, compare: {2}", frequency, limit, compare);
+            this.Log(LogLevel.Info, "Creating ComparingTimers with freq: {0}, limit: 0x{1:X}, compare: {2}, clockSource: {3}, workMode: {4}", frequency, limit, compare, clockSource, workMode);
         }
 
         protected ComparingTimer(IClockSource clockSource, long frequency, ulong limit = ulong.MaxValue, Direction direction = Direction.Ascending, bool enabled = false, WorkMode workMode = WorkMode.OneShot, bool eventEnabled = false, ulong compare = ulong.MaxValue, uint divider = 1, uint step = 1) 
@@ -65,7 +65,9 @@ namespace Antmicro.Renode.Peripherals.Timers
             }
             set
             {
+                
                 clockSource.ExchangeClockEntryWith(CompareReachedInternal, oldEntry => oldEntry.With(enabled: value));
+                this.Log(LogLevel.Info, "Setting ComparingTimers enabled to: {0}", value);
             }
         }
 
@@ -189,7 +191,7 @@ namespace Antmicro.Renode.Peripherals.Timers
             {
                 return;
             }
-            this.Log(LogLevel.Info, "ComparingTimers: reaching CompareReacehd");
+            this.Log(LogLevel.Info, "ComparingTimers: reaching CompareReached");
 
             CompareReached?.Invoke();
         }
@@ -209,6 +211,7 @@ namespace Antmicro.Renode.Peripherals.Timers
         {
             // since we use OneShot, timer's value is already 0 and it is disabled now
             // first we add old limit to accumulated value:
+            this.Log(LogLevel.Info, "Reaching CompareReachedInternal");
             valueAccumulatedSoFar += clockSource.GetClockEntry(CompareReachedInternal).Period;
             if(valueAccumulatedSoFar >= initialLimit && compareValue != initialLimit)
             {

--- a/src/Emulator/Main/Peripherals/Timers/ComparingTimer.cs
+++ b/src/Emulator/Main/Peripherals/Timers/ComparingTimer.cs
@@ -10,7 +10,6 @@ using Antmicro.Renode.Core;
 using Antmicro.Renode.Time;
 using Antmicro.Renode.Exceptions;
 using Antmicro.Renode.Utilities;
-using Antmicro.Renode.Logging;
 
 namespace Antmicro.Renode.Peripherals.Timers
 {
@@ -49,7 +48,6 @@ namespace Antmicro.Renode.Peripherals.Timers
             this.owner = this is IPeripheral && owner == null ? this : owner;
             this.localName = localName;
             InternalReset();
-            //this.Log(LogLevel.Info, "Creating ComparingTimers with freq: {0}, limit: 0x{1:X}, compare: {2:X}, clockSource: {3}, workMode: {4}", frequency, limit, compare, clockSource, workMode);
         }
 
         protected ComparingTimer(IClockSource clockSource, long frequency, ulong limit = ulong.MaxValue, Direction direction = Direction.Ascending, bool enabled = false, WorkMode workMode = WorkMode.OneShot, bool eventEnabled = false, ulong compare = ulong.MaxValue, uint divider = 1, uint step = 1) 
@@ -67,7 +65,6 @@ namespace Antmicro.Renode.Peripherals.Timers
             {
                 
                 clockSource.ExchangeClockEntryWith(CompareReachedInternal, oldEntry => oldEntry.With(enabled: value));
-                //this.Log(LogLevel.Info, "Setting ComparingTimers enabled to: {0}", value);
             }
         }
 
@@ -99,7 +96,6 @@ namespace Antmicro.Renode.Peripherals.Timers
                 {
                     currentValue = valueAccumulatedSoFar + entry.Value;
                 });
-                //this.Log(LogLevel.Info, "ComparingTimers value: {0}", currentValue);
                 return currentValue;
             }
             set
@@ -112,7 +108,6 @@ namespace Antmicro.Renode.Peripherals.Timers
                 clockSource.ExchangeClockEntryWith(CompareReachedInternal, entry =>
                 {
                     valueAccumulatedSoFar = value;
-                    //this.Log(LogLevel.Info, "ComparingTimers value: 0x{0:X}", value);
                     return entry.With(period: CalculatePeriod(), value: 0);
                 });
             }
@@ -134,7 +129,6 @@ namespace Antmicro.Renode.Peripherals.Timers
                 {
                     compareValue = value;
                     valueAccumulatedSoFar += entry.Value;
-                    //this.Log(LogLevel.Info, "ComparingTimer compare value: 0x{0:X} , valueAccumulatedSoFar: 0x{1:X}", value, valueAccumulatedSoFar);
                     return entry.With(period: CalculatePeriod(), value: 0);
                 });
             }
@@ -191,7 +185,6 @@ namespace Antmicro.Renode.Peripherals.Timers
             {
                 return;
             }
-            //this.Log(LogLevel.Info, "ComparingTimers: reaching CompareReached");
 
             CompareReached?.Invoke();
         }
@@ -211,7 +204,6 @@ namespace Antmicro.Renode.Peripherals.Timers
         {
             // since we use OneShot, timer's value is already 0 and it is disabled now
             // first we add old limit to accumulated value:
-            //this.Log(LogLevel.Info, "Reaching CompareReachedInternal");
             valueAccumulatedSoFar += clockSource.GetClockEntry(CompareReachedInternal).Period;
             if(valueAccumulatedSoFar >= initialLimit && compareValue != initialLimit)
             {

--- a/src/Emulator/Peripherals/Peripherals.csproj
+++ b/src/Emulator/Peripherals/Peripherals.csproj
@@ -67,6 +67,7 @@
     <Compile Include="Peripherals\MTD\CFIFlash.cs" />
     <Compile Include="Peripherals\UART\NS16550.cs" />
     <Compile Include="Peripherals\UART\ATCUART100.cs" />
+    <Compile Include="Peripherals\Timers\ATCPIT100.cs" />
     <Compile Include="Peripherals\UART\AxiUartLite.cs" />
     <Compile Include="Peripherals\Input\AntMouse.cs" />
     <Compile Include="Peripherals\MTD\CFIFlashExtensions.cs" />

--- a/src/Emulator/Peripherals/Peripherals/Timers/ATCPIT100.cs
+++ b/src/Emulator/Peripherals/Peripherals/Timers/ATCPIT100.cs
@@ -1,0 +1,328 @@
+//
+// Copyright (c) 2010-2023 Antmicro
+//
+// This file is licensed under the MIT License.
+// Full license text is available in 'licenses/MIT.txt'.
+//
+using Antmicro.Renode.Core;
+using Antmicro.Renode.Peripherals.CPU;
+using Antmicro.Renode.Core.Structure.Registers;
+using Antmicro.Renode.Logging;
+using Antmicro.Renode.Time;
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace Antmicro.Renode.Peripherals.Timers
+{
+    public class ATCPIT100 : BasicDoubleWordPeripheral, INumberedGPIOOutput, IKnownSize
+    {
+        public ATCPIT100(Machine machine) : base(machine)
+        {
+            var innerConnections = new Dictionary<int, IGPIO>();
+            internalTimers = new InternalTimer[TimersCount];
+            for(var i = 0; i < TimersCount; ++i)
+            {
+                internalTimers[i] = new InternalTimer(this, machine.ClockSource, i);
+                internalTimers[i].OnCompare += UpdateInterrupts;
+                innerConnections[i] = new GPIO();
+            }
+
+            timerEnabled = new IFlagRegisterField[TimersCount];
+            functionSelect = new IEnumRegisterField<FunctionSelect>[TimersCount];
+
+            Connections = new ReadOnlyDictionary<int, IGPIO>(innerConnections);
+
+            DefineRegisters();
+            Reset();
+        }
+
+        public override void Reset()
+        {
+            base.Reset();
+            for(var i = 0; i < TimersCount; ++i)
+            {
+                internalTimers[i].Reset();
+                Connections[i].Unset();
+            }
+        }
+
+        public IReadOnlyDictionary<int, IGPIO> Connections { get; }
+
+        private void RequestReturnOnAllCPUs()
+        {
+            foreach(var cpu in machine.GetPeripheralsOfType<TranslationCPU>())
+            {
+                cpu.RequestReturn();
+            }
+        }
+
+        private void UpdateTimerActiveStatus()
+        {
+            for(var i = 0 ; i < TimersCount; ++i)
+            {
+                internalTimers[i].Enabled = timerEnabled[i].Value; //use 
+            }
+
+            RequestReturnOnAllCPUs();
+        }
+
+        private void UpdateInterrupts()
+        {
+            for(var i = 0; i < TimersCount; ++i)
+            {
+                var interrupt = false;
+                interrupt |= internalTimers[i].Compare0Event && internalTimers[i].Compare0Interrupt;
+                interrupt |= internalTimers[i].Compare1Event && internalTimers[i].Compare1Interrupt;
+
+                if(Connections[i].IsSet != interrupt)
+                {
+                    this.NoisyLog("Changing Interrupt{0} from {1} to {2}", i, Connections[i].IsSet, interrupt);
+                }
+
+                Connections[i].Set(interrupt);
+            }
+        }
+
+        
+
+
+
+        //define registers here, add read/write callback, define bitfields
+        private void DefineRegisters()
+        {
+            Registers.Cfg.Define(this)
+                .WithReservedBits(3,31)
+                .WithValueField(0, 3, FieldMode.Read, name:"NumCh",
+                    valueProviderCallback: valueProviderCallback: _ => channelCount)
+            ;
+
+            Registers.IntEn.Define(this)
+                .WithReservedBits(16,31)
+                .WithFlag(15, FieldMode.Set, name: "Ch3Int3En",
+                    changeCallback: _ => ChannelN_InterruptM_En[3][3])
+                .WithFlag(14, FieldMode.Set, name: "Ch3Int2En",
+                    changeCallback: _ => ChannelN_InterruptM_En[3][2])
+            ;
+            Registers.IntSt.Define(this)
+                //implement R/W here using ChannelN_InterruptM_St[][]
+            ;
+            Registers.ChEn.Define(this)
+                //implement R/W here using ChannelN_TimerM_EN[][]
+            ;
+            Registers.Ch0Ctrl.Define(this) //Channel 0 Control Register
+                //implement R/W here using ChannelN_Control_PWM_Park, ChannelN_Control_ChClk, ChannelN_Control_ChMode
+            ;
+            Registers.Ch0Reload.Define(this) //Channel 0 Reload Register
+                //implement R/W here using ChannelN_Reload
+            ;
+            Registers.Ch0Cntr.Define(this) //Channel 0 Counter Register
+                //implement R/W here
+            ;
+            Registers.Ch1Ctrl.Define(this) //Channel 1 Control Register
+                //implement R/W here using ChannelN_Control_PWM_Park, ChannelN_Control_ChClk, ChannelN_Control_ChMode
+            ;
+            Registers.Ch1Reload.Define(this) //Channel 1 Reload Register
+                //implement R/W here using ChannelN_Reload
+            ;
+            Registers.Ch1Cntr.Define(this) //Channel 1 Counter Register
+                //implement R/W here
+            ;
+            Registers.Ch2Ctrl.Define(this) //Channel 2 Control Register
+                //implement R/W here using ChannelN_Control_PWM_Park, ChannelN_Control_ChClk, ChannelN_Control_ChMode
+            ;
+            Registers.Ch2Reload.Define(this) //Channel 2 Reload Register
+                //implement R/W here using ChannelN_Reload
+            ;
+            Registers.Ch2Cntr.Define(this) //Channel 2 Counter Register
+                //implement R/W here
+            ;
+            Registers.Ch3Ctrl.Define(this) //Channel 3 Control Register
+                //implement R/W here using ChannelN_Control_PWM_Park, ChannelN_Control_ChClk, ChannelN_Control_ChMode
+            ;
+            Registers.Ch3Reload.Define(this) //Channel 3 Reload Register
+                //implement R/W here using ChannelN_Reload
+            ;
+            Registers.Ch3Cntr.Define(this) //Channel 3 Counter Register
+                //implement R/W here
+            ;
+        }
+
+        private readonly InternalTimer[] internalTimers;
+
+        private IFlagRegisterField[] timerEnabled;
+
+
+        private const int channelCount = 4;
+
+        //register values variables
+        private const bool [4][4] ChannelN_InterruptM_En;       //ChannelN_InterruptM_En [0][1] is channel 0 interrupt 1 enable
+        private const bool [4][4] ChannelN_InterruptM_St;       //ChannelN_InterruptM_St [0][1] is channel 0 interrupt 1 status
+        private const bool [4][4] ChannelN_TimerM_En;           //ChannelN_TimerM_En [0][1] is channel 0 timer 1 enable
+
+        private const bool [4] ChannelN_Control_PWM_Park;       //Channel N's PWM park value
+        private const bool [4] ChannelN_Control_ChClk;          //Channel N's clock source (0 = External clock, 1 = APB Clock)
+        private const ChannelMode [4] ChannelN_Control_ChMode;  //Channel N's channel mode
+
+        private const uint [4] ChannelN_Reload;                 //Channel N's reload value(s), depends on ChannelN_Control_ChMode
+
+        private const uint [4] ChannelN_Counter;                //Channel N's Counter value(s), depends on ChannelN_Control_ChMode
+
+        private const int TimersCount = 16;
+
+        private class InternalTimer
+        {
+            public InternalTimer(IPeripheral parent, IClockSource clockSource, int index)
+            {
+                compare0Timer = new ComparingTimer(clockSource, 1, parent, $"timer{index}cmp0", limit: 0xFFFFFFFF, compare: 0xFFFFFFFF, enabled: false);
+                compare1Timer = new ComparingTimer(clockSource, 1, parent, $"timer{index}cmp1", limit: 0xFFFFFFFF, compare: 0xFFFFFFFF, enabled: false);
+
+                compare0Timer.CompareReached += () =>
+                {
+                    Compare0Event = true;
+                    CompareReached();
+                };
+                compare1Timer.CompareReached += () =>
+                {
+                    Compare1Event = true;
+                    CompareReached();
+                };
+            }
+
+            public void Reset()
+            {
+                Enabled = false;
+                Compare0Event = false;
+                Compare1Event = false;
+            }
+
+            public bool Enabled
+            {
+                get => compare0Timer.Enabled;
+                set
+                {
+                    if(Enabled == value)
+                    {
+                        return;
+                    }
+
+                    Value = 0;
+                    compare0Timer.Enabled = value;
+                    compare1Timer.Enabled = value;
+                }
+            }
+
+            public bool OneShot { get; set; }
+
+            public ulong Value
+            {
+                get => compare0Timer.Value;
+                set
+                {
+                    compare0Timer.Value = value;
+                    compare1Timer.Value = value;
+                }
+            }
+
+            public long Frequency
+            {
+                get => compare0Timer.Frequency;
+                set
+                {
+                    compare0Timer.Frequency = value;
+                    compare1Timer.Frequency = value;
+                }
+            }
+
+            public uint Divider
+            {
+                get => compare0Timer.Divider;
+                set
+                {
+                    compare0Timer.Divider = value;
+                    compare1Timer.Divider = value;
+                }
+            }
+
+            public ulong Compare0
+            {
+                get => compare0Timer.Compare;
+                set => compare0Timer.Compare = value;
+            }
+
+            public ulong Compare1
+            {
+                get => compare1Timer.Compare;
+                set => compare1Timer.Compare = value;
+            }
+
+            public bool Compare0Event { get; set; }
+            public bool Compare1Event { get; set; }
+
+            public bool Compare0Interrupt
+            {
+                get => compare0Timer.EventEnabled;
+                set => compare0Timer.EventEnabled = value;
+            }
+
+            public bool Compare1Interrupt
+            {
+                get => compare1Timer.EventEnabled;
+                set => compare1Timer.EventEnabled = value;
+            }
+
+            public Action OnCompare;
+
+            private void CompareReached()
+            {
+                OnCompare?.Invoke();
+
+                if(OneShot)
+                {
+                    Value = 0;
+                }
+            }
+
+            private readonly ComparingTimer compare0Timer;
+            private readonly ComparingTimer compare1Timer;
+        }
+
+        private enum ChannelMode : ushort 
+        {
+            Timer_32bit     = 1, // one 32 bit timer 0
+            Timer_16bit     = 2, // two 16 bit timers 0 - 1
+            Timer_8bit      = 3, // four 8 bit timers 0 - 3
+            PWM             = 4, // 16 bit PWM
+            PWM_Timer_16bit = 6, // 8 bit PWM and 16 bit timer 0
+            PWM_Timer_8bit  = 7; // 8 bit PWM and two 8 bit timers 0 - 1
+        }
+
+        private enum Registers : long
+        {
+            IdRev = 0x00,       //ID and Revision Register
+            Cfg   = 0x10,       //Configuration Register
+            IntEn = 0x14,       //Interrupt Enable Register
+            IntSt = 0x18,       //Interrupt Status Register
+
+            ChEn  = 0x1C,       //Channel Enable Register
+
+            Ch0Ctrl = 0x20,     //Channel 0 Control Register
+            Ch0Reload = 0x24,   //Channel 0 Reload Register
+            Ch0Cntr = 0x28,     //Channel 0 Counter Register
+
+            Ch1Ctrl = 0x30,
+            Ch1Reload = 0x34,
+            Ch1Cntr = 0x38,
+
+            Ch2Ctrl = 0x40,
+            Ch2Reload = 0x44,
+            Ch2Cntr = 0x48,
+
+            Ch3Ctrl = 0x50,
+            Ch3Reload = 0x54,
+            Ch3Cntr = 0x58        
+            
+        }
+    }
+}

--- a/src/Emulator/Peripherals/Peripherals/Timers/ATCPIT100.cs
+++ b/src/Emulator/Peripherals/Peripherals/Timers/ATCPIT100.cs
@@ -138,7 +138,7 @@ namespace Antmicro.Renode.Peripherals.Timers
                     case ChannelMode.Timer_32bit:
                         if (timerNum == 0){
                             ChannelN_TimerM_En[channelNum, timerNum] = enableValue;
-                            internalTimers[channelNum, 0].Enabled = enableValue;
+                            internalTimers[channelNum, 0].Enabled = ChannelN_TimerM_En[channelNum, timerNum];
                         }
                         else{
                             this.Log(LogLevel.Error, "Cannot enable timer0 when channel {0} is in {1} mode", 
@@ -731,7 +731,7 @@ namespace Antmicro.Renode.Peripherals.Timers
             {
                 Enabled = false;
                 Compare0Event = false;
-                compare0Timer.Reset();
+                //compare0Timer.Reset();
             }
 
             public bool Enabled

--- a/src/Emulator/Peripherals/Peripherals/Timers/ATCPIT100.cs
+++ b/src/Emulator/Peripherals/Peripherals/Timers/ATCPIT100.cs
@@ -640,11 +640,12 @@ namespace Antmicro.Renode.Peripherals.Timers
         {
             public InternalTimer(IPeripheral parent, IClockSource clockSource, int index, ulong limit)
             {
-                compare0Timer = new ComparingTimer(clockSource, timerFrequency, parent, $"timer{index}cmp0", limit: limit, compare: 0, enabled: false);
+                compare0Timer = new ComparingTimer(clockSource, timerFrequency, parent, $"timer{index}cmp0", limit: limit, compare: limit, enabled: false, workMode: WorkMode.OneShot);
 
                 compare0Timer.CompareReached += () =>
                 {
                     Compare0Event = true;
+                    Console.WriteLine("InternalTimer compareReached");
                     CompareReached();
                 };
             }
@@ -660,7 +661,7 @@ namespace Antmicro.Renode.Peripherals.Timers
                 get => compare0Timer.Enabled;
                 set
                 {
-                    Console. WriteLine("Setting InternalTimer enabled to {0}", value);
+                    Console.WriteLine("Setting InternalTimer enabled to {0}", value);
                     if(Enabled == value)
                     {
                         return;

--- a/src/Emulator/Peripherals/Peripherals/Timers/ATCPIT100.cs
+++ b/src/Emulator/Peripherals/Peripherals/Timers/ATCPIT100.cs
@@ -138,7 +138,7 @@ namespace Antmicro.Renode.Peripherals.Timers
                     case ChannelMode.Timer_32bit:
                         if (timerNum == 0){
                             ChannelN_TimerM_En[channelNum, timerNum] = enableValue;
-                            internalTimers[channelNum, 0].Enabled = ChannelN_TimerM_En[channelNum, timerNum];
+                            internalTimers[channelNum, 0].Enabled = enableValue;
                         }
                         else{
                             this.Log(LogLevel.Error, "Cannot enable timer0 when channel {0} is in {1} mode", 
@@ -720,15 +720,18 @@ namespace Antmicro.Renode.Peripherals.Timers
                 compare0Timer.CompareReached += () =>
                 {
                     Compare0Event = true;
-                    Console.WriteLine("InternalTimer Compare0Event reached");
+                    Console.WriteLine("InternalTimer Compare0Event reached\n");
                     CompareReached();
                 };
+
+                OneShot = true;
             }
 
             public void Reset()
             {
                 Enabled = false;
                 Compare0Event = false;
+                compare0Timer.Reset();
             }
 
             public bool Enabled
@@ -736,7 +739,7 @@ namespace Antmicro.Renode.Peripherals.Timers
                 get => compare0Timer.Enabled;
                 set
                 {
-                    Console.WriteLine("Setting InternalTimer enabled to {0}", value);
+                    Console.WriteLine("Setting InternalTimer enabled to {0}\n", value);
                     if(Enabled == value)
                     {
                         return;
@@ -799,10 +802,13 @@ namespace Antmicro.Renode.Peripherals.Timers
             {
                 OnCompare?.Invoke();
 
+                Console.WriteLine("ATCPIT100.cs: CompareReached: OneShot value {0}\n", OneShot);
+
                 if(OneShot)
                 {
                     Value = 0;
-                    Console.WriteLine("InternalTimer compareReached");
+                    Reset();
+                    Console.WriteLine("InternalTimer compareReached\n");
                 }
             }
 

--- a/src/Emulator/Peripherals/Peripherals/Timers/ATCPIT100.cs
+++ b/src/Emulator/Peripherals/Peripherals/Timers/ATCPIT100.cs
@@ -22,9 +22,6 @@ namespace Antmicro.Renode.Peripherals.Timers
         {
             IRQ = new GPIO();
             internalTimers = new InternalTimer[channelCount, InternalTimersPerChannel];
-
-            this.Log(LogLevel.Info, "clock source: {0}", machine.ClockSource);
-
             for(var i = 0; i < channelCount; ++i)
             {
                 for (var j = 0; j < InternalTimersPerChannel; ++j)
@@ -106,7 +103,7 @@ namespace Antmicro.Renode.Peripherals.Timers
             //if (AreAllIntStatusZero()) interrupt = false;
             if(IRQ.IsSet != interrupt)
             {
-                this.InfoLog("Changing IRQ from {0} to {1}", IRQ.IsSet, interrupt);
+                this.NoisyLog("Changing IRQ from {0} to {1}", IRQ.IsSet, interrupt);
             }
             
             IRQ.Set(interrupt);
@@ -135,8 +132,10 @@ namespace Antmicro.Renode.Peripherals.Timers
                             channelNum, timerNum, enableValue, (ChannelMode)ChannelN_Control_ChMode[channelNum]);
                     }
                     else{
-                        this.Log(LogLevel.Error, "Cannot enable timer {0} when channel {1} is in {2} mode", 
+                        if (enableValue == true){
+                            this.Log(LogLevel.Error, "Cannot enable timer {0} when channel {1} is in {2} mode", 
                             timerNum, channelNum, ChannelN_Control_ChMode[channelNum]);
+                        }
                     }
                     break;
                 case ChannelMode.Timer_16bit:
@@ -147,8 +146,10 @@ namespace Antmicro.Renode.Peripherals.Timers
                             channelNum, timerNum, enableValue, (ChannelMode)ChannelN_Control_ChMode[channelNum]);
                     }
                     else{
-                        this.Log(LogLevel.Error, "Cannot enable timer {0} when channel {1} is in {2} mode", 
+                        if (enableValue == true){
+                            this.Log(LogLevel.Error, "Cannot enable timer {0} when channel {1} is in {2} mode", 
                             timerNum, channelNum, ChannelN_Control_ChMode[channelNum]);
+                        }
                     }
                     break;
                 case ChannelMode.Timer_8bit:
@@ -159,8 +160,10 @@ namespace Antmicro.Renode.Peripherals.Timers
                             channelNum, timerNum, enableValue, (ChannelMode)ChannelN_Control_ChMode[channelNum]);
                     }
                     else{
-                        this.Log(LogLevel.Error, "Cannot enable timer {0} when channel {1} is in {2} mode", 
+                        if (enableValue == true){
+                            this.Log(LogLevel.Error, "Cannot enable timer {0} when channel {1} is in {2} mode", 
                             timerNum, channelNum, ChannelN_Control_ChMode[channelNum]);
+                        }
                     }
                     break;
                 case ChannelMode.PWM:
@@ -175,8 +178,10 @@ namespace Antmicro.Renode.Peripherals.Timers
                             channelNum, timerNum, enableValue, (ChannelMode)ChannelN_Control_ChMode[channelNum]);
                     }
                     else{
-                        this.Log(LogLevel.Error, "Cannot enable timer {0} when channel {1} is in {2} mode", 
+                        if (enableValue == true){
+                            this.Log(LogLevel.Error, "Cannot enable timer {0} when channel {1} is in {2} mode", 
                             timerNum, channelNum, ChannelN_Control_ChMode[channelNum]);
+                        }
                     }
                     break;
                 case ChannelMode.PWM_Timer_8bit:
@@ -188,8 +193,10 @@ namespace Antmicro.Renode.Peripherals.Timers
                             channelNum, timerNum, enableValue, (ChannelMode)ChannelN_Control_ChMode[channelNum]);
                     }
                     else{
-                        this.Log(LogLevel.Error, "Cannot enable timer {0} when channel {1} is in {2} mode", 
+                        if (enableValue == true){
+                            this.Log(LogLevel.Error, "Cannot enable timer {0} when channel {1} is in {2} mode", 
                             timerNum, channelNum, ChannelN_Control_ChMode[channelNum]);
+                        }
                     }
                     break;
             }
@@ -840,7 +847,7 @@ namespace Antmicro.Renode.Peripherals.Timers
                 get => compare0Timer.Enabled;
                 set
                 {
-                    Console.WriteLine("Setting InternalTimer enabled to {0}", value);
+                    //Console.WriteLine("Setting InternalTimer enabled to {0}", value);
                     if(Enabled == value)
                     {
                         return;

--- a/src/Emulator/Peripherals/Peripherals/Timers/ATCPIT100.cs
+++ b/src/Emulator/Peripherals/Peripherals/Timers/ATCPIT100.cs
@@ -664,18 +664,44 @@ namespace Antmicro.Renode.Peripherals.Timers
             ;                
 
             //Channel 0 Counter Register
-            Registers.Ch0Cntr.Define(this) //Channel 0 Counter Register
+            Registers.Ch0Cntr.Define(this)
                 .WithValueField(0, 32, FieldMode.Read, name: "TMR32_0", 
                 valueProviderCallback: _ => { return CounterRegisterReturn(0); } )
             ;
 
             //Channel 1 Control Register
-            Registers.Ch1Ctrl.Define(this) 
+            Registers.Ch1Ctrl.Define(this)
+                .WithReservedBits(5,27)
+                .WithFlag(4, FieldMode.Read | FieldMode.Write, name: "Ch1PwmPark",
+                    changeCallback: (_, value) => { ChannelN_Control_PWM_Park[1] = (bool)value; },
+                    valueProviderCallback: _ => { return ChannelN_Control_PWM_Park[1]; } )
+
+                .WithFlag(3, FieldMode.Read | FieldMode.Write, name: "Ch1clk",
+                    changeCallback: (_, value) => { ChannelN_Control_ChClk[1] = (bool)value; },
+                    valueProviderCallback: _ => { return ChannelN_Control_ChClk[1]; } )
+
+                .WithValueField(0, 3, FieldMode.Read | FieldMode.Write, name: "Ch1Mode", 
+                    changeCallback: (_, value) => 
+                    { 
+                        if (Enum.IsDefined(typeof(ChannelMode), (ushort)value))
+                        {
+                            ChannelN_Control_ChMode[1] = (ChannelMode)(ushort)value;
+                            this.InfoLog("Setting channel 1 mode to {0}", (ChannelMode)(ushort)value);
+                        }
+                        else
+                        {
+                            this.Log(LogLevel.Error, "Channel 1: unknown channel mode");
+                        }
+                    },
+                    valueProviderCallback: _ => { return (ulong)ChannelN_Control_ChMode[1]; } )
 
             ;
 
             //Channel 1 Reload
             Registers.Ch1Reload.Define(this)
+                .WithValueField(0, 32, FieldMode.Read | FieldMode.Write, name: "TMR32_1", 
+                    changeCallback: (_, newValue) => ReloadRegister(1, newValue),
+                    valueProviderCallback: _ => { return ReloadRegisterReturn(1); } )
 
             ;  
 
@@ -686,11 +712,37 @@ namespace Antmicro.Renode.Peripherals.Timers
 
             //Channel 2 Control Register
             Registers.Ch2Ctrl.Define(this)
+                .WithReservedBits(5,27)
+                .WithFlag(4, FieldMode.Read | FieldMode.Write, name: "Ch2PwmPark",
+                    changeCallback: (_, value) => { ChannelN_Control_PWM_Park[2] = (bool)value; },
+                    valueProviderCallback: _ => { return ChannelN_Control_PWM_Park[2]; } )
+
+                .WithFlag(3, FieldMode.Read | FieldMode.Write, name: "Ch2clk",
+                    changeCallback: (_, value) => { ChannelN_Control_ChClk[2] = (bool)value; },
+                    valueProviderCallback: _ => { return ChannelN_Control_ChClk[2]; } )
+
+                .WithValueField(0, 3, FieldMode.Read | FieldMode.Write, name: "Ch2Mode", 
+                    changeCallback: (_, value) => 
+                    { 
+                        if (Enum.IsDefined(typeof(ChannelMode), (ushort)value))
+                        {
+                            ChannelN_Control_ChMode[2] = (ChannelMode)(ushort)value;
+                            this.InfoLog("Setting channel 2 mode to {0}", (ChannelMode)(ushort)value);
+                        }
+                        else
+                        {
+                            this.Log(LogLevel.Error, "Channel 2: unknown channel mode");
+                        }
+                    },
+                    valueProviderCallback: _ => { return (ulong)ChannelN_Control_ChMode[2]; } )
              
             ;
 
             //Channel 2 Reload Register
-            Registers.Ch2Reload.Define(this) 
+            Registers.Ch2Reload.Define(this)
+                .WithValueField(0, 32, FieldMode.Read | FieldMode.Write, name: "TMR32_0", 
+                    changeCallback: (_, newValue) => ReloadRegister(2, newValue),
+                    valueProviderCallback: _ => { return ReloadRegisterReturn(2); } )
                 
             ;
 
@@ -701,11 +753,36 @@ namespace Antmicro.Renode.Peripherals.Timers
 
             //Channel 3 Control Register
             Registers.Ch3Ctrl.Define(this)
-            
+                .WithReservedBits(5,27)
+                .WithFlag(4, FieldMode.Read | FieldMode.Write, name: "Ch3PwmPark",
+                    changeCallback: (_, value) => { ChannelN_Control_PWM_Park[3] = (bool)value; },
+                    valueProviderCallback: _ => { return ChannelN_Control_PWM_Park[3]; } )
+
+                .WithFlag(3, FieldMode.Read | FieldMode.Write, name: "Ch3clk",
+                    changeCallback: (_, value) => { ChannelN_Control_ChClk[3] = (bool)value; },
+                    valueProviderCallback: _ => { return ChannelN_Control_ChClk[3]; } )
+
+                .WithValueField(0, 3, FieldMode.Read | FieldMode.Write, name: "Ch3Mode", 
+                    changeCallback: (_, value) => 
+                    { 
+                        if (Enum.IsDefined(typeof(ChannelMode), (ushort)value))
+                        {
+                            ChannelN_Control_ChMode[3] = (ChannelMode)(ushort)value;
+                            this.InfoLog("Setting channel 3 mode to {0}", (ChannelMode)(ushort)value);
+                        }
+                        else
+                        {
+                            this.Log(LogLevel.Error, "Channel 3: unknown channel mode");
+                        }
+                    },
+                    valueProviderCallback: _ => { return (ulong)ChannelN_Control_ChMode[3]; } )
             ;
 
             //Channel 3 Reload Register
             Registers.Ch3Reload.Define(this)
+                .WithValueField(0, 32, FieldMode.Read | FieldMode.Write, name: "TMR32_3", 
+                    changeCallback: (_, newValue) => ReloadRegister(3, newValue),
+                    valueProviderCallback: _ => { return ReloadRegisterReturn(3); } )
                 
             ;
 

--- a/src/Emulator/Peripherals/Peripherals/Timers/ATCPIT100.cs
+++ b/src/Emulator/Peripherals/Peripherals/Timers/ATCPIT100.cs
@@ -90,22 +90,24 @@ namespace Antmicro.Renode.Peripherals.Timers
             }
         }
 
-        bool interrupt = false;
+        
         private void UpdateInterrupts()
         {
+            bool interrupt = false;
             for(var i = 0; i < channelCount; i++){
                 for(var j = 0; j < TimersPerChannel; j++){
                     ChannelN_InterruptM_St[i,j] = InterruptStatusReturn(i, j);
-                    if ((i == 0) && (j == 0)) this.InfoLog("ChannelN_InterruptM_St = {0}, ChannelN_InterruptM_En = {1} i = {2}, j = {3}", ChannelN_InterruptM_St[i, j], ChannelN_InterruptM_En[i, j], i, j);          
-                    interrupt |= (ChannelN_InterruptM_St[i, j] && ChannelN_InterruptM_En[i, j]);
-                    if (AreAllIntStatusZero()) interrupt = false;
-                    
+                    //if ((i == 0) && (j <= 1)) this.InfoLog("ChannelN_InterruptM_St = {0}, ChannelN_InterruptM_En = {1} i = {2}, j = {3}", ChannelN_InterruptM_St[i, j], ChannelN_InterruptM_En[i, j], i, j);          
+                    interrupt |= (ChannelN_InterruptM_St[i, j] && ChannelN_InterruptM_En[i, j]);                   
+                    if (interrupt) break;
                 }
+                if (interrupt) break;
             }
+            //if (AreAllIntStatusZero()) interrupt = false;
             if(IRQ.IsSet != interrupt)
-                    {
-                        this.InfoLog("Changing IRQ from {0} to {1}", IRQ.IsSet, interrupt);
-                    }
+            {
+                this.InfoLog("Changing IRQ from {0} to {1}", IRQ.IsSet, interrupt);
+            }
             
             IRQ.Set(interrupt);
         }        
@@ -118,6 +120,7 @@ namespace Antmicro.Renode.Peripherals.Timers
                     }
                 }
             }
+            //this.InfoLog("AreAllIntStatusZero = true");
             return true;
 
         }
@@ -128,7 +131,7 @@ namespace Antmicro.Renode.Peripherals.Timers
                     if (timerNum == 0){
                         ChannelN_TimerM_En[channelNum, timerNum] = enableValue;
                         internalTimers[channelNum, timerNum].Enabled = ChannelN_TimerM_En[channelNum, timerNum];
-                        this.InfoLog("Enabling/disabling ch{0} timer{1}'s with value {2}, channel mode {3}", 
+                        this.InfoLog("Enabling/disabling ch{0} timer{1} with value {2}, channel mode {3}", 
                             channelNum, timerNum, enableValue, (ChannelMode)ChannelN_Control_ChMode[channelNum]);
                     }
                     else{
@@ -140,7 +143,7 @@ namespace Antmicro.Renode.Peripherals.Timers
                     if ((timerNum == 0) || (timerNum == 1)){
                         ChannelN_TimerM_En[channelNum, timerNum] = enableValue;
                         internalTimers[channelNum, timerNum + 1].Enabled = ChannelN_TimerM_En[channelNum, timerNum];
-                        this.InfoLog("Enabling/disabling ch{0} timer{1}'s with value {2}, channel mode {3}", 
+                        this.InfoLog("Enabling/disabling ch{0} timer{1} with value {2}, channel mode {3}", 
                             channelNum, timerNum, enableValue, (ChannelMode)ChannelN_Control_ChMode[channelNum]);
                     }
                     else{
@@ -152,7 +155,7 @@ namespace Antmicro.Renode.Peripherals.Timers
                     if ((timerNum >= 0) && (timerNum <= 3)){
                         ChannelN_TimerM_En[channelNum, timerNum] = enableValue;
                         internalTimers[channelNum, timerNum + 3].Enabled = ChannelN_TimerM_En[channelNum, timerNum];
-                        this.InfoLog("Enabling/disabling ch{0} timer{1}'s with value {2}, channel mode {3}", 
+                        this.InfoLog("Enabling/disabling ch{0} timer{1} with value {2}, channel mode {3}", 
                             channelNum, timerNum, enableValue, (ChannelMode)ChannelN_Control_ChMode[channelNum]);
                     }
                     else{
@@ -168,7 +171,7 @@ namespace Antmicro.Renode.Peripherals.Timers
                     if (timerNum == 0){
                         ChannelN_TimerM_En[channelNum, timerNum] = enableValue;
                         internalTimers[channelNum, 0].Enabled = ChannelN_TimerM_En[channelNum, timerNum];
-                        this.InfoLog("Enabling/disabling ch{0} timer{1}'s with value {2}, channel mode {3}", 
+                        this.InfoLog("Enabling/disabling ch{0} timer{1} with value {2}, channel mode {3}", 
                             channelNum, timerNum, enableValue, (ChannelMode)ChannelN_Control_ChMode[channelNum]);
                     }
                     else{
@@ -181,7 +184,7 @@ namespace Antmicro.Renode.Peripherals.Timers
                     if ((timerNum == 0) || (timerNum == 1)){
                         ChannelN_TimerM_En[channelNum, timerNum] = enableValue;
                         internalTimers[channelNum, timerNum + 1].Enabled = ChannelN_TimerM_En[channelNum, timerNum];
-                        this.InfoLog("Enabling/disabling ch{0} timer{1}'s with value {2}, channel mode {3}", 
+                        this.InfoLog("Enabling/disabling ch{0} timer{1} with value {2}, channel mode {3}", 
                             channelNum, timerNum, enableValue, (ChannelMode)ChannelN_Control_ChMode[channelNum]);
                     }
                     else{
@@ -382,7 +385,7 @@ namespace Antmicro.Renode.Peripherals.Timers
                     returnVal = false;
                     break;
             }
-            UpdateInterrupts();
+            //UpdateInterrupts();
             return returnVal;
         }
 
@@ -655,14 +658,14 @@ namespace Antmicro.Renode.Peripherals.Timers
 
             //Channel 0 Reload Register
             Registers.Ch0Reload.Define(this)
-                .WithValueField(0, 31, FieldMode.Read | FieldMode.Write, name: "TMR32_0", 
+                .WithValueField(0, 32, FieldMode.Read | FieldMode.Write, name: "TMR32_0", 
                     changeCallback: (_, newValue) => ReloadRegister(0, newValue),
                     valueProviderCallback: _ => { return ReloadRegisterReturn(0); } )
             ;                
 
             //Channel 0 Counter Register
             Registers.Ch0Cntr.Define(this) //Channel 0 Counter Register
-                .WithValueField(0, 31, FieldMode.Read, name: "TMR32_0", 
+                .WithValueField(0, 32, FieldMode.Read, name: "TMR32_0", 
                 valueProviderCallback: _ => { return CounterRegisterReturn(0); } )
             ;
 

--- a/src/Emulator/Peripherals/Peripherals/Timers/ATCPIT100.cs
+++ b/src/Emulator/Peripherals/Peripherals/Timers/ATCPIT100.cs
@@ -94,13 +94,12 @@ namespace Antmicro.Renode.Peripherals.Timers
             for(var i = 0; i < channelCount; i++){
                 for(var j = 0; j < TimersPerChannel; j++){
                     ChannelN_InterruptM_St[i,j] = InterruptStatusReturn(i, j);
-                    //if ((i == 0) && (j <= 1)) this.InfoLog("ChannelN_InterruptM_St = {0}, ChannelN_InterruptM_En = {1} i = {2}, j = {3}", ChannelN_InterruptM_St[i, j], ChannelN_InterruptM_En[i, j], i, j);          
+                    this.NoisyLog("ChannelN_InterruptM_St = {0}, ChannelN_InterruptM_En = {1} i = {2}, j = {3}", ChannelN_InterruptM_St[i, j], ChannelN_InterruptM_En[i, j], i, j);          
                     interrupt |= (ChannelN_InterruptM_St[i, j] && ChannelN_InterruptM_En[i, j]);                   
                     if (interrupt) break;
                 }
                 if (interrupt) break;
             }
-            //if (AreAllIntStatusZero()) interrupt = false;
             if(IRQ.IsSet != interrupt)
             {
                 this.NoisyLog("Changing IRQ from {0} to {1}", IRQ.IsSet, interrupt);
@@ -108,19 +107,6 @@ namespace Antmicro.Renode.Peripherals.Timers
             
             IRQ.Set(interrupt);
         }        
-
-        private bool AreAllIntStatusZero(){
-            for(var i = 0; i < channelCount; i++){
-                for(var j = 0; j < TimersPerChannel; j++){
-                    if (ChannelN_InterruptM_St[i,j] == true){
-                        return false;
-                    }
-                }
-            }
-            //this.InfoLog("AreAllIntStatusZero = true");
-            return true;
-
-        }
 
         private void TimerEnable(int channelNum, int timerNum, bool enableValue){
             switch (ChannelN_Control_ChMode[channelNum]){
@@ -237,7 +223,7 @@ namespace Antmicro.Renode.Peripherals.Timers
             return returnVal;
         }
 
-        private void ReloadRegister(int channelNum, ulong reloadValue){ //TODO: should we check if timer is en before reloading?
+        private void ReloadRegister(int channelNum, ulong reloadValue){
             /*
              * set channel n reload value depending on ChannelN_Control_ChMode[] by bitshifting values
              */
@@ -271,7 +257,7 @@ namespace Antmicro.Renode.Peripherals.Timers
                         channelNum, reloadValue, (ChannelMode)ChannelN_Control_ChMode[channelNum]);
         }
 
-        private uint ReloadRegisterReturn(int channelNum){ //TODO
+        private uint ReloadRegisterReturn(int channelNum){
             switch(ChannelN_Control_ChMode[channelNum]){
                 case ChannelMode.Timer_32bit:
                     ChannelN_Reload[channelNum, 0] = (uint) internalTimers[channelNum, 0].Compare0;
@@ -294,7 +280,7 @@ namespace Antmicro.Renode.Peripherals.Timers
         }
 
         private uint CounterRegisterReturn(int channelNum){
-            return 0; //temp
+            return 0;
         } //TODO
 
         private void InterruptEnable(int channelNum, int timerNum, bool interruptValue){
@@ -392,13 +378,11 @@ namespace Antmicro.Renode.Peripherals.Timers
                     returnVal = false;
                     break;
             }
-            //UpdateInterrupts();
             return returnVal;
         }
 
         private void InterruptStatus(int channelNum, int timerNum, bool value){
             //value is inverted by W1C control in register before function call
-            //Console.WriteLine("intstatus() value: {0}" , value);
             if (!value){
                 switch (ChannelN_Control_ChMode[channelNum]){
                     case ChannelMode.Timer_32bit:
@@ -449,9 +433,8 @@ namespace Antmicro.Renode.Peripherals.Timers
                     }
                     break;
             }
-            //this.InfoLog("status of ch{0} timer{1}'s is {2} with channel mode {3}",
-              //  channelNum, timerNum, ChannelN_InterruptM_St[channelNum, timerNum], (ChannelMode)ChannelN_Control_ChMode[channelNum]);
-            //UpdateInterrupts();
+            this.NoisyLog("status of ch{0} timer{1} is {2} with channel mode {3}",
+                channelNum, timerNum, ChannelN_InterruptM_St[channelNum, timerNum], (ChannelMode)ChannelN_Control_ChMode[channelNum]);
             return returnvalue;
         }
 
@@ -829,7 +812,6 @@ namespace Antmicro.Renode.Peripherals.Timers
                 compare0Timer.CompareReached += () =>
                 {
                     Compare0Event = true;
-                    //Console.WriteLine("InternalTimer channel {0} timer {1} Compare0Event reached with value {0}", chnum, index, Compare0Event);
                     CompareReached();
                 };
 
@@ -847,7 +829,6 @@ namespace Antmicro.Renode.Peripherals.Timers
                 get => compare0Timer.Enabled;
                 set
                 {
-                    //Console.WriteLine("Setting InternalTimer enabled to {0}", value);
                     if(Enabled == value)
                     {
                         return;
@@ -910,12 +891,9 @@ namespace Antmicro.Renode.Peripherals.Timers
             {
                 OnCompare?.Invoke();
 
-                //Console.WriteLine("ATCPIT100.cs: CompareReached: OneShot value {0}\n", OneShot);
-
                 if(OneShot)
                 {
                     Value = 0;
-                    //Console.WriteLine("InternalTimer compareReached\n");
                 }
             }
 


### PR DESCRIPTION
### **Summary**

Create Renode support for ATCPIT100 GPT based on Andes datasheet information. GPT timer supports all 4 channels running in 32 bit, 16 bit, or 8 bit modes. Skeleton and reference from AmbiqApollo4_Timer.cs file. The ATCPIT100.cs Renode file uses 7 internal timers (from the InternalTimers class) per channel (one 32b, two 16b, four 8b), which create comparing timers to do actual timing.

Not supported: ID and Revision Register (0x00), different clock sources for channels (ChClk field in control registers), PWM functionality. 

### **Testing**

Single channel tests:
| ChMode | Num timers & channels | test 1 - oneshot | test 2 - continuous |
| ------------- | ------------- | ------------- | ------------- |
| 32 bit | ch 0, timer 0 | Success  | Success |
| 16 bit | ch 0, timers 0 - 1 | Success  | Success |
| 8 bit | ch 0, timers 0 - 3 | Success  | Success |

Multi channel tests:
| ChMode | Num timers & channels | test 1 - oneshot | test 2 - continuous |
| ------------- | ------------- | ------------- | ------------- |
| 32 bit | ch 0 timer 0; ch 1 timer 0 | Success  | Success |
| 16 bit | ch 0 timers 0, 1; ch 1 timers 0, 1 | Success  | Success |
| 8 bit | ch 0 timers 0 - 3; ch 1 timers 0 - 2; ch 2 timers 0 - 1; ch 3 timer 0 | Success  | Success |

oneshot - clear interrupt, disable timer, disable interrupt
continuous - clear interrupt but do not disable timer or interrupt


