### PR TITLE
Initial Virgo Support

### DIFF
--- a/src/Emulator/Cores/RiscV/Andes_N22.cs
+++ b/src/Emulator/Cores/RiscV/Andes_N22.cs
@@ -18,7 +18,7 @@ namespace Antmicro.Renode.Peripherals.CPU
     public class Andes_N22 : RiscV32
     {
 
-        public Andes_N22(IMachine machine, IRiscVTimeProvider timeProvider = null, string cpuType = "rv32imac", uint hartId = 0, uint resetVectorAddress = 0x0)
+        public Andes_N22(IMachine machine, IRiscVTimeProvider timeProvider = null, string cpuType = "rv32imac_zicsr", uint hartId = 0, uint resetVectorAddress = 0x0)
             : base(timeProvider: timeProvider, cpuType: cpuType, machine: machine, hartId: hartId, allowUnalignedAccesses: true, nmiVectorLength: 1, nmiVectorAddress: resetVectorAddress)
         {
             this.resetVectorAddress = resetVectorAddress;
@@ -52,19 +52,11 @@ namespace Antmicro.Renode.Peripherals.CPU
             {
                 // For now, only support special logic for when NMI is modified
                 MMISC_CTL = w;
-                bool newNMI = BitHelper.IsBitSet(w, 9);
-                if (newNMI)
-                {
-                    NMIVectorAddress = MTVEC; 
-                }
-                else
-                {
-                    NMIVectorAddress = resetVectorAddress;
-                }
             });
 
         }
-        public override void Reset(){
+        public override void Reset()
+        {
             base.Reset();
             PC = resetVectorAddress;
         }
@@ -106,6 +98,14 @@ namespace Antmicro.Renode.Peripherals.CPU
         {
 
             bool newNmi = BitHelper.IsBitSet(MMISC_CTL, 9);
+            if (newNmi)
+            {
+                NMIVectorAddress = MTVEC & 0xFFFFFFFC;
+            }
+            else
+            {
+                NMIVectorAddress = resetVectorAddress;
+            }
             base.OnNMI(number, value, newNmi ? 0xFFFUL : 1);
         }
 
@@ -125,7 +125,7 @@ namespace Antmicro.Renode.Peripherals.CPU
             MMISC_CTL_RW = 0x7d0,
             PUSHMXSTATUS_RW = 0x7eb, // Hook to CSRRWI
             MIRQ_ENTRY_RW = 0x7ec,
-            MINTSEL_JAL = 0x7ed,
+            MINTSEL_JAL = 0x7ed, //Should be in the CLIC
             PUSHMCAUSE_RW = 0x7ee, // Hook to CSRRWI
             PUSHMEPC_RW = 0x7ef, // Hook to CSRRWI
             UITB_RW = 0x800,

--- a/src/Emulator/Cores/RiscV/Andes_N22.cs
+++ b/src/Emulator/Cores/RiscV/Andes_N22.cs
@@ -1,0 +1,80 @@
+﻿//
+// Copyright (c) 2023 Rapid Silicon
+//
+//  This file is licensed under the MIT License.
+//  Full license text is available in 'licenses/MIT.txt'.
+//
+using Antmicro.Renode.Core;
+using Antmicro.Renode.Logging;
+using Antmicro.Renode.Peripherals.Timers;
+using Antmicro.Renode.Utilities;
+using Endianess = ELFSharp.ELF.Endianess;
+
+namespace Antmicro.Renode.Peripherals.CPU
+{
+    public class Andes_N22 : RiscV32
+    {
+
+        private enum AndestarV5CSR
+        {
+            MTVT_RW = 0x307,
+            MDLMB_RW = 0x7c1,
+            MNVEC_RO = 0x7c3,
+            MXSTATUS_RW = 0x7c4,
+            MPFT_CTL_RW = 0x7c5,
+            MHSP_CTL_RW = 0x7c6,
+            MCACHE_CTL_RW = 0x7ca,
+            MMISC_CTL_RW = 0x7d0,
+            PUSHMXSTATUS_RW = 0x7eb, // Hook to CSRRWI
+            MIRQ_ENTRY_RW = 0x7ec,
+            MINTSEL_JAL = 0x7ed,
+            PUSHMCAUSE_RW = 0x7ee, // Hook to CSRRWI
+            PUSHMEPC_RW = 0x7ef, // Hook to CSRRWI
+            UITB_RW = 0x800,
+            UCODE_RW = 0x801,
+            MMSC_CFG_RO = 0xFC2
+        }
+        public Andes_N22(Machine machine, IRiscVTimeProvider timeProvider = null, uint hartId = 0, PrivilegeArchitecture privilegeArchitecture = PrivilegeArchitecture.Priv1_11, Endianess endianness = Endianess.LittleEndian, string cpuType = "rv32imac")
+            : base(null, cpuType, machine, hartId, privilegeArchitecture, endianness, allowUnalignedAccesses: true)
+        {
+            AndestarV5CSR[] rw_csrs = {
+                AndestarV5CSR.MTVT_RW, AndestarV5CSR.MDLMB_RW,
+                AndestarV5CSR.MXSTATUS_RW, AndestarV5CSR.MPFT_CTL_RW,
+                AndestarV5CSR.MHSP_CTL_RW, AndestarV5CSR.MCACHE_CTL_RW,
+                AndestarV5CSR.MMISC_CTL_RW, AndestarV5CSR.PUSHMXSTATUS_RW,
+                AndestarV5CSR.MIRQ_ENTRY_RW, AndestarV5CSR.MINTSEL_JAL,
+                AndestarV5CSR.PUSHMCAUSE_RW, AndestarV5CSR.PUSHMEPC_RW,
+                AndestarV5CSR.UITB_RW, AndestarV5CSR.UCODE_RW, };
+            AndestarV5CSR[] ro_csrs = { AndestarV5CSR.MNVEC_RO, AndestarV5CSR.MMSC_CFG_RO };
+            foreach (AndestarV5CSR csr in rw_csrs)
+            {
+                RegisterCSR((ulong)csr,
+                    () => LogUnhandledCSRRead(csr.ToString()),
+                    val => LogUnhandledCSRWrite(csr.ToString(), val));
+            }
+            foreach (AndestarV5CSR csr in ro_csrs)
+            {
+                RegisterCSR((ulong)csr,
+                    () => LogUnhandledCSRRead(csr.ToString()),
+                    val => LogWriteOnReadOnlyCSR(csr.ToString(), val));
+            }
+            //AddPostOpcodeExecutionHook(,,(opcode)=>); CSRRWI execution hook 
+            EnablePostOpcodeExecutionHooks(1);
+        }
+
+        private ulong LogUnhandledCSRRead(string name)
+        {
+            this.Log(LogLevel.Error, "Reading from an unsupported CSR {0}", name);
+            return 0u;
+        }
+
+        private void LogUnhandledCSRWrite(string name, ulong value)
+        {
+            this.Log(LogLevel.Error, "Writing to an unsupported CSR {0} value: 0x{1:X}", name, value);
+        }
+        private void LogWriteOnReadOnlyCSR(string name, ulong value)
+        {
+            this.Log(LogLevel.Error, "Writing to RO CSR {0} value: 0x{1:X}", name, value);
+        }
+    }
+}

--- a/src/Emulator/Cores/cores-riscv.csproj
+++ b/src/Emulator/Cores/cores-riscv.csproj
@@ -60,6 +60,7 @@
     <Compile Include="RiscV\RiscVInstructionPythonEngine.cs" />
     <Compile Include="RiscV\RiscVCsrPythonEngine.cs" />
     <Compile Include="RiscV\CV32E40P.cs" />
+    <Compile Include="RiscV\Andes_N22.cs" />
     <Compile Include="RiscV\Andes_A45.cs" />
     <Compile Include="RiscV\PULP_InterruptController.cs" />
     <Compile Include="RiscV\PULP_EventController.cs" />

--- a/src/Emulator/Cores/cores-riscv_NET.csproj
+++ b/src/Emulator/Cores/cores-riscv_NET.csproj
@@ -40,6 +40,7 @@
     <Compile Include="RiscV\RiscVInstructionPythonEngine.cs" />
     <Compile Include="RiscV\RiscVCsrPythonEngine.cs" />
     <Compile Include="RiscV\CV32E40P.cs" />
+    <Compile Include="RiscV\Andes_N22.cs" />
     <Compile Include="RiscV\Andes_A45.cs" />
     <Compile Include="RiscV\PULP_InterruptController.cs" />
     <Compile Include="RiscV\PULP_EventController.cs" />

--- a/src/Emulator/Peripherals/Peripherals.csproj
+++ b/src/Emulator/Peripherals/Peripherals.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Peripherals\Timers\ATCPIT100.cs" />
     <Compile Include="Peripherals\Timers\ATCWDT200.cs" />
     <Compile Include="Peripherals\GPIOPort\ATCGPIO100.cs" />
+    <Compile Include="Peripherals\Miscellaneous\RS_SystemControlUnit.cs" />
     <Compile Include="Peripherals\UART\AxiUartLite.cs" />
     <Compile Include="Peripherals\Input\AntMouse.cs" />
     <Compile Include="Peripherals\MTD\CFIFlashExtensions.cs" />

--- a/src/Emulator/Peripherals/Peripherals/Miscellaneous/RS_SystemControlUnit.cs
+++ b/src/Emulator/Peripherals/Peripherals/Miscellaneous/RS_SystemControlUnit.cs
@@ -5,10 +5,9 @@ using Antmicro.Renode.Peripherals.CPU;
 
 namespace Antmicro.Renode.Peripherals.Miscellaneous
 {
-    public class RS_SystemControlUnit<T> : BasicDoubleWordPeripheral, IKnownSize, IGPIOReceiver
-        where T : BaseCPU, ICPUWithNMI
+    public class RS_SystemControlUnit : BasicDoubleWordPeripheral, IKnownSize, IGPIOReceiver
     {
-        public RS_SystemControlUnit(IMachine machine,long version, T bcpu = null, T acpu= null) : base(machine)
+        public RS_SystemControlUnit(IMachine machine,long version, ICPUWithNMI bcpu = null, ICPUWithNMI acpu= null) : base(machine)
         {
             this.version = version;
             this.bcpu = bcpu;
@@ -30,12 +29,11 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
 
                     break;
                 case InputPort.BcpuWdt:
+                    bcpu.OnNMI(0, value, null);
                     break;
                 default:
                     break;
             }
-            
-
         }
         private enum Registers : long
         {
@@ -78,8 +76,8 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
         }
         public long Size => 0x3FFF;
         private long version;
-        private T bcpu;
-        private T acpu;
+        private ICPUWithNMI bcpu;
+        private ICPUWithNMI acpu;
 
         public enum InputPort: int{
             

--- a/src/Emulator/Peripherals/Peripherals/Miscellaneous/RS_SystemControlUnit.cs
+++ b/src/Emulator/Peripherals/Peripherals/Miscellaneous/RS_SystemControlUnit.cs
@@ -5,12 +5,14 @@ using Antmicro.Renode.Peripherals.CPU;
 
 namespace Antmicro.Renode.Peripherals.Miscellaneous
 {
-    public class RS_SystemControlUnit<T> : BasicDoubleWordPeripheral, IKnownSize
+    public class RS_SystemControlUnit<T> : BasicDoubleWordPeripheral, IKnownSize, IGPIOReceiver
         where T : BaseCPU, ICPUWithNMI
     {
-        public RS_SystemControlUnit(IMachine machine,long version, T bcpu, T acpu) : base(machine)
+        public RS_SystemControlUnit(IMachine machine,long version, T bcpu = null, T acpu= null) : base(machine)
         {
             this.version = version;
+            this.bcpu = bcpu;
+            this.acpu = acpu;
         }
         private void DefineRegisters()
         {
@@ -19,6 +21,21 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
             {
                 {(long)Registers.IdRev, new DoubleWordRegister(this, 0x10475253)},
             };
+        }
+
+        public void OnGPIO(int number, bool value)
+        {
+            switch((InputPort)number){
+                case InputPort.AcpuWdt:
+
+                    break;
+                case InputPort.BcpuWdt:
+                    break;
+                default:
+                    break;
+            }
+            
+
         }
         private enum Registers : long
         {
@@ -61,5 +78,112 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
         }
         public long Size => 0x3FFF;
         private long version;
+        private T bcpu;
+        private T acpu;
+
+        public enum InputPort: int{
+            
+            Bootstrap0 = 0x0,
+            Bootstrap1 = 0x1,
+            BcpuWdt = 0x2,
+            AcpuWdt = 0x3,
+            Irq1 = 0x4,
+            Irq2 = 0x5,
+            Irq3 = 0x6,
+            Irq4 = 0x7,
+            Irq5 = 0x8,
+            Irq6 = 0x9,
+            Irq7 = 0x10,
+            Irq8 = 0x11,
+            Irq9 = 0x12,
+            Irq10 = 0x13,
+            Irq11 = 0x14,
+            Irq12 = 0x15,
+            Irq13 = 0x16,
+            Irq14 = 0x17,
+            Irq15 = 0x18,
+            Irq16 = 0x19,
+            Irq17 = 0x20,
+            Irq18 = 0x21,
+            Irq19 = 0x22,
+            Irq20 = 0x23,
+            Irq21 = 0x24,
+            Irq22 = 0x25,
+            Irq23 = 0x26,
+            Irq24 = 0x27,
+            Irq25 = 0x28,
+            Irq26 = 0x29,
+            Irq27 = 0x30,
+            Irq28 = 0x31,
+            Irq29 = 0x32,
+            Irq30 = 0x33,
+            Irq31 = 0x34
+        }
+
+        // WDTs not covered in output ports as NMI is called direcly via the OnNMI function 
+        public enum OutputPorts: long{
+            BcpuIrq1,
+            BcpuIrq2,
+            BcpuIrq3,
+            BcpuIrq4,
+            BcpuIrq5,
+            BcpuIrq6,
+            BcpuIrq7,
+            BcpuIrq8,
+            BcpuIrq9,
+            BcpuIrq10,
+            BcpuIrq11,
+            BcpuIrq12,
+            BcpuIrq13,
+            BcpuIrq14,
+            BcpuIrq15,
+            BcpuIrq16,
+            BcpuIrq17,
+            BcpuIrq18,
+            BcpuIrq19,
+            BcpuIrq20,
+            BcpuIrq21,
+            BcpuIrq22,
+            BcpuIrq23,
+            BcpuIrq24,
+            BcpuIrq25,
+            BcpuIrq26,
+            BcpuIrq27,
+            BcpuIrq28,
+            BcpuIrq29,
+            BcpuIrq30,
+            BcpuIrq31,
+            AcpuIrq1,
+            AcpuIrq2,
+            AcpuIrq3,
+            AcpuIrq4,
+            AcpuIrq5,
+            AcpuIrq6,
+            AcpuIrq7,
+            AcpuIrq8,
+            AcpuIrq9,
+            AcpuIrq10,
+            AcpuIrq11,
+            AcpuIrq12,
+            AcpuIrq13,
+            AcpuIrq14,
+            AcpuIrq15,
+            AcpuIrq16,
+            AcpuIrq17,
+            AcpuIrq18,
+            AcpuIrq19,
+            AcpuIrq20,
+            AcpuIrq21,
+            AcpuIrq22,
+            AcpuIrq23,
+            AcpuIrq24,
+            AcpuIrq25,
+            AcpuIrq26,
+            AcpuIrq27,
+            AcpuIrq28,
+            AcpuIrq29,
+            AcpuIrq30,
+            AcpuIrq31
+        }
     }
 }

--- a/src/Emulator/Peripherals/Peripherals/Miscellaneous/RS_SystemControlUnit.cs
+++ b/src/Emulator/Peripherals/Peripherals/Miscellaneous/RS_SystemControlUnit.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+using Antmicro.Renode.Core;
+using Antmicro.Renode.Core.Structure.Registers;
+using Antmicro.Renode.Peripherals.CPU;
+
+namespace Antmicro.Renode.Peripherals.Miscellaneous
+{
+    public class RS_SystemControlUnit<T> : BasicDoubleWordPeripheral, IKnownSize
+        where T : BaseCPU, ICPUWithNMI
+    {
+        public RS_SystemControlUnit(IMachine machine,long version, T bcpu, T acpu) : base(machine)
+        {
+            this.version = version;
+        }
+        private void DefineRegisters()
+        {
+            long idrevReset = (version == (long)RS_SystemControlUnitVersion.Gemini) ? 0x10475253 : 0x10565253;
+            var registersMap = new Dictionary<long, DoubleWordRegister>
+            {
+                {(long)Registers.IdRev, new DoubleWordRegister(this, 0x10475253)},
+            };
+        }
+        private enum Registers : long
+        {
+            IdRev = 0x0,
+            SoftwareResetConttrol = 0x4,
+            PllConfig0 = 0x8,
+            PllConfig1 = 0xC,
+            PllConfig2 = 0x10,
+            PllConfig3 = 0x14,
+            PllConfig4 = 0x18,
+            PllStatus = 0x1C,
+            DividerControl = 0x20,
+            GatingControl = 0x24,
+            DebugControl = 0x28,
+            IrqAcpuBcpuWdtMask = 0x2C,
+            IrqMaskMapControl_n = 0x30, // n in [1,31]
+            IsolationControl = 0xAC,
+            BootstrapStatus = 0xB0,
+            MainDividerControl = 0xB4,
+            PufccControl = 0xB8,
+            UsbControl = 0xBC,
+            FpgaPll = 0xC0,
+            WdtPause = 0xC4,
+            DDRMode = 0xC8,
+            OscillatorControl = 0xCC,
+            GptPause = 0xD0,
+            SramControl0 = 0xD4,
+            SramControl1 = 0xD8,
+            AcpuResetVector = 0xDC,
+            AcpuMemoryMargin = 0xE0,
+            MemorySubSystemMemoryMargin = 0xE4,
+            ConfigSubSystemMemoryMargin = 0xE8,
+            PadsModeControlSlewRateControl = 0xEC,
+            SpareReg = 0xF0
+        }
+        public enum RS_SystemControlUnitVersion : long
+        {
+            Gemini = 0x0,
+            Virgo = 0x1
+        }
+        public long Size => 0x3FFF;
+        private long version;
+    }
+}


### PR DESCRIPTION
These are some of the base changes for Virgo Support, without complete SCU support. 

This basically adds the N22 core, some of the Andes custom CSRs we use in that core and some minimal SCU support in order to support NMI logic. I'm opening this before going on PTO so other team members can start testing on top of the basic virgo platform. As soon as this is approved I'll also open a PR to add the rs_virgo.repl to the renode_rs repo  