### PR TITLE
Add Virgo_pad

### DIFF
--- a/src/Emulator/Main/Peripherals/Bus/Redirector.cs
+++ b/src/Emulator/Main/Peripherals/Bus/Redirector.cs
@@ -34,12 +34,13 @@ namespace Antmicro.Renode.Peripherals.Bus
         }
 
         public byte ReadByte(long offset)
-        {
+        {   Console.WriteLine("ReadByte " );
             return systemBus.ReadByte(redirectedAddress + checked((ulong)offset));
         }
 
         public void WriteByte(long offset, byte value)
-        {
+        {  
+            Console.WriteLine("WriteByte" );
             systemBus.WriteByte(redirectedAddress + checked((ulong)offset), value);
         }
 
@@ -76,12 +77,12 @@ namespace Antmicro.Renode.Peripherals.Bus
         }
 
         public byte[] ReadBytes(long offset, int count, ICPU context = null)
-        {
+        {   Console.WriteLine("ReadBytes array" );
             return systemBus.ReadBytes(redirectedAddress + checked((ulong)offset), count, context: context);
         }
 
         public void WriteBytes(long offset, byte[] array, int startingIndex, int count, ICPU context = null)
-        {
+        {  Console.WriteLine("Write bytes array" );
             systemBus.WriteBytes(array, redirectedAddress + checked((ulong)offset), count, context: context);
         }
 

--- a/src/Emulator/Main/Peripherals/Bus/Redirector.cs
+++ b/src/Emulator/Main/Peripherals/Bus/Redirector.cs
@@ -1,3 +1,4 @@
+
 //
 // Copyright (c) 2010-2023 Antmicro
 // Copyright (c) 2011-2015 Realtime Embedded
@@ -34,13 +35,12 @@ namespace Antmicro.Renode.Peripherals.Bus
         }
 
         public byte ReadByte(long offset)
-        {   Console.WriteLine("ReadByte " );
+        {
             return systemBus.ReadByte(redirectedAddress + checked((ulong)offset));
         }
 
         public void WriteByte(long offset, byte value)
-        {  
-            Console.WriteLine("WriteByte" );
+        {
             systemBus.WriteByte(redirectedAddress + checked((ulong)offset), value);
         }
 
@@ -77,12 +77,12 @@ namespace Antmicro.Renode.Peripherals.Bus
         }
 
         public byte[] ReadBytes(long offset, int count, ICPU context = null)
-        {   Console.WriteLine("ReadBytes array" );
+        {
             return systemBus.ReadBytes(redirectedAddress + checked((ulong)offset), count, context: context);
         }
 
         public void WriteBytes(long offset, byte[] array, int startingIndex, int count, ICPU context = null)
-        {  Console.WriteLine("Write bytes array" );
+        {
             systemBus.WriteBytes(array, redirectedAddress + checked((ulong)offset), count, context: context);
         }
 
@@ -100,4 +100,3 @@ namespace Antmicro.Renode.Peripherals.Bus
         private readonly IBusController systemBus;
     }
 }
-

--- a/src/Emulator/Main/Peripherals/Bus/SystemBus.cs
+++ b/src/Emulator/Main/Peripherals/Bus/SystemBus.cs
@@ -535,8 +535,8 @@ namespace Antmicro.Renode.Peripherals.Bus
                     {
                         checked
                         {    Console.WriteLine("Sysbus WriteBytes 2");
-                           // multibytePeripheral.WriteBytes(checked((long)(target.Offset - target.What.RegistrationPoint.Range.StartAddress + target.What.RegistrationPoint.Offset)), bytes, startingIndex + (int)target.SourceIndex, (int)target.SourceLength);
-                            multibytePeripheral.WriteBytes(checked((long)(target.Offset - target.What.RegistrationPoint.Range.StartAddress + target.What.RegistrationPoint.Offset)), bytes, startingIndex - (int)target.SourceIndex, (int)target.SourceLength);
+                             multibytePeripheral.WriteBytes(checked((long)(target.Offset - target.What.RegistrationPoint.Range.StartAddress + target.What.RegistrationPoint.Offset)), bytes, startingIndex + (int)target.SourceIndex, (int)target.SourceLength);
+                           
                         }
                     }
                     else

--- a/src/Emulator/Main/Peripherals/Bus/SystemBus.cs
+++ b/src/Emulator/Main/Peripherals/Bus/SystemBus.cs
@@ -484,7 +484,7 @@ namespace Antmicro.Renode.Peripherals.Bus
                         checked
                         {
                             memory.ReadBytes(checked((long)(target.Offset - target.What.RegistrationPoint.Range.StartAddress + target.What.RegistrationPoint.Offset)), (int)target.SourceLength, destination, startIndex + (int)target.SourceIndex);
-                            Console.WriteLine("Sysbus check1");
+                            Console.WriteLine("Sysbus ReadBytes 1");
                         }
                     }
                     else
@@ -492,6 +492,7 @@ namespace Antmicro.Renode.Peripherals.Bus
                         for(var i = 0UL; i < target.SourceLength; ++i)
                         {
                             destination[checked((ulong)startIndex) + target.SourceIndex + i] = ReadByte(target.Offset + i, context);
+                             Console.WriteLine("Sysbus ReadBytes 2");
                         }
                     }
                 }
@@ -502,7 +503,7 @@ namespace Antmicro.Renode.Peripherals.Bus
         {
             var result = new byte[count];
             ReadBytes(address, count, result, 0, onlyMemory, context);
-              Console.WriteLine("Sysbus check2");
+              Console.WriteLine("Sysbus Readbytes 3");
             return result;
         }
 
@@ -512,8 +513,10 @@ namespace Antmicro.Renode.Peripherals.Bus
         }
 
         public void WriteBytes(byte[] bytes, ulong address, bool onlyMemory = false, ICPU context = null)
-        {
+        {  
+             Console.WriteLine("Sysbus WriteBytes 1");
             WriteBytes(bytes, address, bytes.Length, onlyMemory, context);
+            
         }
 
         public void WriteBytes(byte[] bytes, ulong address, int startingIndex, long count, bool onlyMemory = false, ICPU context = null)
@@ -531,14 +534,14 @@ namespace Antmicro.Renode.Peripherals.Bus
                     if(multibytePeripheral != null)
                     {
                         checked
-                        {
+                        {    Console.WriteLine("Sysbus WriteBytes 2");
                             multibytePeripheral.WriteBytes(checked((long)(target.Offset - target.What.RegistrationPoint.Range.StartAddress + target.What.RegistrationPoint.Offset)), bytes, startingIndex + (int)target.SourceIndex, (int)target.SourceLength);
                         }
                     }
                     else
                     {
                         for(var i = 0UL; i < target.SourceLength; ++i)
-                        {
+                        {   Console.WriteLine("Sysbus WriteBytes 3");
                             WriteByte(target.Offset + i, bytes[target.SourceIndex + (ulong)startingIndex + i]);
                         }
                     }

--- a/src/Emulator/Main/Peripherals/Bus/SystemBus.cs
+++ b/src/Emulator/Main/Peripherals/Bus/SystemBus.cs
@@ -1,4 +1,3 @@
-
 //
 // Copyright (c) 2010-2024 Antmicro
 // Copyright (c) 2011-2015 Realtime Embedded
@@ -579,14 +578,11 @@ namespace Antmicro.Renode.Peripherals.Bus
             WriteBytes(zeroBlock, range.StartAddress + blocksNo * (ulong)zeroBlock.Length, (int)range.Size % zeroBlock.Length, context: context);
         }
 
-        // Specifying `textAddress` will override the address of the program text - the symbols will be applied
-        // as if the first loaded segment started at the specified address. This is equivalent to the ADDR parameter
-        // to GDB's add-symbol-file.
-        public void LoadSymbolsFrom(ReadFilePath fileName, bool useVirtualAddress = false, ulong? textAddress = null)
+        public void LoadSymbolsFrom(ReadFilePath fileName, bool useVirtualAddress = false)
         {
             using (var elf = GetELFFromFile(fileName))
             {
-                Lookup.LoadELF(elf, useVirtualAddress, textAddress);
+                Lookup.LoadELF(elf, useVirtualAddress);
             }
             pcCache.Invalidate();
         }
@@ -986,18 +982,6 @@ namespace Antmicro.Renode.Peripherals.Bus
             }
         }
 
-        public void SetAddressRangeLocked(Range range, bool locked)
-        {
-            if(locked)
-            {
-                lockedRangesCollection.Add(range);
-            }
-            else
-            {
-                lockedRangesCollection.Remove(range);
-            }
-        }
-
         public void SetPeripheralEnabled(IPeripheral peripheral, bool enabled)
         {
             if(enabled)
@@ -1011,11 +995,6 @@ namespace Antmicro.Renode.Peripherals.Bus
                     lockedPeripherals.Add(peripheral);
                 }
             }
-        }
-
-        public bool IsAddressRangeLocked(Range range)
-        {
-            return lockedRangesCollection.ContainsOverlappingRange(range);
         }
 
         public bool IsPeripheralEnabled(IPeripheral peripheral)
@@ -1157,7 +1136,7 @@ namespace Antmicro.Renode.Peripherals.Bus
                 }
             }
             var perCoreRegistration = registrationPoint as IPerCoreRegistration;
-            if(perCoreRegistration?.CPU != null)
+            if(perCoreRegistration.CPU != null)
             {
                 cpuLocalPeripherals[perCoreRegistration.CPU].Remove(registrationPoint.RegistrationPoint.Range.StartAddress, registrationPoint.RegistrationPoint.Range.EndAddress);
             }
@@ -1672,7 +1651,6 @@ namespace Antmicro.Renode.Peripherals.Bus
             globalPeripherals = new PeripheralCollection(this);
             cpuLocalPeripherals = new Dictionary<ICPU, PeripheralCollection>();
             lockedPeripherals = new HashSet<IPeripheral>();
-            lockedRangesCollection = new MinimalRangesCollection();
             mappingsForPeripheral = new Dictionary<IBusPeripheral, List<MappedSegmentWrapper>>();
             tags = new Dictionary<Range, TagEntry>();
             svdDevices = new List<SVDParser>();
@@ -1864,7 +1842,6 @@ namespace Antmicro.Renode.Peripherals.Bus
         private PeripheralCollection globalPeripherals;
         private Dictionary<ICPU, PeripheralCollection> cpuLocalPeripherals;
         private ISet<IPeripheral> lockedPeripherals;
-        private MinimalRangesCollection lockedRangesCollection;
         private Dictionary<IBusPeripheral, List<MappedSegmentWrapper>> mappingsForPeripheral;
         private bool mappingsRemoved;
         private bool peripheralRegistered;

--- a/src/Emulator/Main/Peripherals/Bus/SystemBus.cs
+++ b/src/Emulator/Main/Peripherals/Bus/SystemBus.cs
@@ -535,7 +535,8 @@ namespace Antmicro.Renode.Peripherals.Bus
                     {
                         checked
                         {    Console.WriteLine("Sysbus WriteBytes 2");
-                            multibytePeripheral.WriteBytes(checked((long)(target.Offset - target.What.RegistrationPoint.Range.StartAddress + target.What.RegistrationPoint.Offset)), bytes, startingIndex + (int)target.SourceIndex, (int)target.SourceLength);
+                           // multibytePeripheral.WriteBytes(checked((long)(target.Offset - target.What.RegistrationPoint.Range.StartAddress + target.What.RegistrationPoint.Offset)), bytes, startingIndex + (int)target.SourceIndex, (int)target.SourceLength);
+                            multibytePeripheral.WriteBytes(checked((long)(target.Offset - target.What.RegistrationPoint.Range.StartAddress + target.What.RegistrationPoint.Offset)), bytes, startingIndex - (int)target.SourceIndex, (int)target.SourceLength);
                         }
                     }
                     else

--- a/src/Emulator/Main/Peripherals/Bus/SystemBus.cs
+++ b/src/Emulator/Main/Peripherals/Bus/SystemBus.cs
@@ -65,7 +65,7 @@ namespace Antmicro.Renode.Peripherals.Bus
 
         public void Unregister(IBusPeripheral peripheral)
         {
-            using(Machine.ObtainPausedState(true))
+            using(Machine.ObtainPausedState())
             {
                 Machine.UnregisterAsAChildOf(this, peripheral);
                 UnregisterInner(peripheral);
@@ -74,7 +74,7 @@ namespace Antmicro.Renode.Peripherals.Bus
 
         public void Unregister(IBusRegistered<IBusPeripheral> busRegisteredPeripheral)
         {
-            using(Machine.ObtainPausedState(true))
+            using(Machine.ObtainPausedState())
             {
                 Machine.UnregisterAsAChildOf(this, busRegisteredPeripheral.RegistrationPoint);
                 UnregisterInner(busRegisteredPeripheral);
@@ -83,7 +83,7 @@ namespace Antmicro.Renode.Peripherals.Bus
 
         public void Unregister(IPeripheral peripheral)
         {
-            using(Machine.ObtainPausedState(true))
+            using(Machine.ObtainPausedState())
             {
                 Machine.UnregisterAsAChildOf(this, peripheral);
             }
@@ -91,7 +91,7 @@ namespace Antmicro.Renode.Peripherals.Bus
 
         public void Register(IPeripheral peripheral, NullRegistrationPoint registrationPoint)
         {
-            using(Machine.ObtainPausedState(true))
+            using(Machine.ObtainPausedState())
             {
                 // NullRegistrationPoint peripherals are not mapped on the bus and
                 // are not directly accessible from the emulated software.
@@ -139,9 +139,11 @@ namespace Antmicro.Renode.Peripherals.Bus
             {
                 throw new RecoverableException("Moving a peripheral is supported only from context's CPU thread");
             }
-            var wasMapped = RemoveMappingsForPeripheral(peripheral);
-            var container = context != null ? cpuLocalPeripherals[context] : globalPeripherals;
-            var registrationPoints = container.Peripherals.Where(x => x.Peripheral == peripheral).ToList();
+            if(mappingsForPeripheral.ContainsKey(peripheral))
+            {
+                throw new RecoverableException("Moving mapped peripherals is not yet supported");
+            }
+            var registrationPoints = cpuLocalPeripherals[context].Peripherals.Where(x => x.Peripheral == peripheral).ToList();
             if(registrationPoints.Count == 0)
             {
                 throw new RecoverableException("Attempted to move a peripheral that isn't registered within current context");
@@ -163,12 +165,8 @@ namespace Antmicro.Renode.Peripherals.Bus
                 }
                 registrationPoint = registrationPoints[0];
             }
-            var newRegistrationPoint = container.Move(registrationPoint, newAddress);
+            var newRegistrationPoint = cpuLocalPeripherals[context].Move(registrationPoint, newAddress);
             Machine.ExchangeRegistrationPointForPeripheral(this, peripheral, registrationPoint.RegistrationPoint, newRegistrationPoint.RegistrationPoint);
-            if(wasMapped)
-            {
-                AddMappingsForPeripheral(peripheral, newRegistrationPoint.RegistrationPoint, context);
-            }
         }
 
         public void Register(ICPU cpu, CPURegistrationPoint registrationPoint)
@@ -200,23 +198,12 @@ namespace Antmicro.Renode.Peripherals.Bus
                         memoryMappedCpu.MapMemory(mapping);
                     }
                 }
-
-                if(cpu.Endianness != Endianess)
-                {
-                    hasCpuWithMismatchedEndianness = true;
-                    UpdateAccessMethods();
-                }
-
-                if(GetCPUs().Select(x => x.Endianness).Distinct().Count() > 1)
-                {
-                    throw new RegistrationException("Currently there can't be CPUs with different endiannesses on the same bus.");
-                }
             }
         }
 
         public void Unregister(ICPU cpu)
         {
-            using(Machine.ObtainPausedState(true))
+            using(Machine.ObtainPausedState())
             {
                 Machine.UnregisterAsAChildOf(this, cpu);
                 lock(cpuSync)
@@ -231,7 +218,7 @@ namespace Antmicro.Renode.Peripherals.Bus
 
         public void SetPCOnAllCores(ulong pc)
         {
-            using(Machine.ObtainPausedState(true))
+            using(Machine.ObtainPausedState())
             {
                 lock(cpuSync)
                 {
@@ -1108,7 +1095,14 @@ namespace Antmicro.Renode.Peripherals.Bus
 
         private void UnregisterInner(IBusPeripheral peripheral)
         {
-            RemoveMappingsForPeripheral(peripheral);
+            if(mappingsForPeripheral.ContainsKey(peripheral))
+            {
+                foreach(var mapping in mappingsForPeripheral[peripheral])
+                {
+                    UnmapMemory(new Range(mapping.StartingOffset, checked((ulong)mapping.Size)));
+                }
+                mappingsForPeripheral.Remove(peripheral);
+            }
 
             // remove the peripheral from all cpu-local and the global mappings
             foreach(var context in cpuLocalPeripherals.Keys.ToArray())
@@ -1166,7 +1160,6 @@ namespace Antmicro.Renode.Peripherals.Bus
         private void FillAccessMethodsWithTaggedMethods(IBusPeripheral peripheral, string tag, ref PeripheralAccessMethods methods)
         {
             methods.Peripheral = peripheral;
-            methods.Tag = tag;
 
             var customAccessMethods = new Dictionary<Tuple<BusAccess.Method, BusAccess.Operation>, MethodInfo>();
             foreach(var method in peripheral.GetType().GetMethods())
@@ -1241,35 +1234,12 @@ namespace Antmicro.Renode.Peripherals.Bus
             // We need to pass in Endianess as a default because at this point the peripheral
             // is not yet associated with a machine.
             Endianess periEndianess = peripheral.GetEndianness(Endianess);
-            // Note that the condition for applying ReadByteUsingDwordBigEndian et al is different than the condition
-            // for byte-swapping correctly-sized accesses! The former is needed for all big-endian peripherals, the
-            // latter - only in the cross-endianness case. This is to ensure that on a big-endian bus, reading a byte
-            // at offset 0 from a peripheral that only supports double word access and has a single register with value
-            // 0x11223344 correctly returns 0x11, and not 0x44 as it would if ReadByteUsingDword were used.
-            var translatedAccessNeedsSwap = Endianess == Endianess.BigEndian;
-            var matchingAccessNeedsSwap = periEndianess != Endianess;
 
             var allowedTranslations = default(AllowedTranslation);
             var allowedTranslationsAttributes = peripheral.GetType().GetCustomAttributes(typeof(AllowedTranslationsAttribute), true);
             if(allowedTranslationsAttributes.Length != 0)
             {
                 allowedTranslations = ((AllowedTranslationsAttribute)allowedTranslationsAttributes[0]).AllowedTranslations;
-            }
-
-            // If the CPU endianness does not match the bus endianness, this endianness mismatch
-            // is basically an additional swap. Instead of performing it we reverse the condition.
-            // This is the case on PowerPC, for example: there the translation library is always built
-            // in big-endian mode, and if the CPU is running in little-endian mode, it performs byte
-            // swapping separately. This is to support switching endianness at runtime, but note that
-            // if this is actually done, peripheral accesses will be reversed.
-            if(hasCpuWithMismatchedEndianness)
-            {
-                matchingAccessNeedsSwap = !matchingAccessNeedsSwap;
-                translatedAccessNeedsSwap = !translatedAccessNeedsSwap;
-                // Other translation types will behave incorrectly in this case.
-                allowedTranslations &=
-                    AllowedTranslation.ByteToWord | AllowedTranslation.ByteToDoubleWord | AllowedTranslation.ByteToQuadWord |
-                    AllowedTranslation.WordToByte | AllowedTranslation.DoubleWordToByte | AllowedTranslation.QuadWordToByte;
             }
 
             if(methods.ReadByte == null) // they are null or not always in pairs
@@ -1281,35 +1251,34 @@ namespace Antmicro.Renode.Peripherals.Bus
                 }
                 else if(qwordWrapper != null && (allowedTranslations & AllowedTranslation.ByteToQuadWord) != 0)
                 {
-                    methods.ReadByte = translatedAccessNeedsSwap ? (BusAccess.ByteReadMethod)qwordWrapper.ReadByteUsingQwordBigEndian : qwordWrapper.ReadByteUsingQword;
-                    methods.WriteByte = translatedAccessNeedsSwap ? (BusAccess.ByteWriteMethod)qwordWrapper.WriteByteUsingQwordBigEndian : qwordWrapper.WriteByteUsingQword;
+                    methods.ReadByte = periEndianess == Endianess.LittleEndian ? (BusAccess.ByteReadMethod)qwordWrapper.ReadByteUsingQword : qwordWrapper.ReadByteUsingQwordBigEndian;
+                    methods.WriteByte = periEndianess == Endianess.LittleEndian ? (BusAccess.ByteWriteMethod)qwordWrapper.WriteByteUsingQword : qwordWrapper.WriteByteUsingQwordBigEndian;
                 }
                 else if(dwordWrapper != null && (allowedTranslations & AllowedTranslation.ByteToDoubleWord) != 0)
                 {
-                    methods.ReadByte = translatedAccessNeedsSwap ? (BusAccess.ByteReadMethod)dwordWrapper.ReadByteUsingDwordBigEndian : dwordWrapper.ReadByteUsingDword;
-                    methods.WriteByte = translatedAccessNeedsSwap ? (BusAccess.ByteWriteMethod)dwordWrapper.WriteByteUsingDwordBigEndian : dwordWrapper.WriteByteUsingDword;
+                    methods.ReadByte = periEndianess == Endianess.LittleEndian ? (BusAccess.ByteReadMethod)dwordWrapper.ReadByteUsingDword : dwordWrapper.ReadByteUsingDwordBigEndian;
+                    methods.WriteByte = periEndianess == Endianess.LittleEndian ? (BusAccess.ByteWriteMethod)dwordWrapper.WriteByteUsingDword : dwordWrapper.WriteByteUsingDwordBigEndian;
                 }
                 else if(wordWrapper != null && (allowedTranslations & AllowedTranslation.ByteToWord) != 0)
                 {
-                    methods.ReadByte = translatedAccessNeedsSwap ? (BusAccess.ByteReadMethod)wordWrapper.ReadByteUsingWordBigEndian : wordWrapper.ReadByteUsingWord;
-                    methods.WriteByte = translatedAccessNeedsSwap ? (BusAccess.ByteWriteMethod)wordWrapper.WriteByteUsingWordBigEndian : wordWrapper.WriteByteUsingWord;
+                    methods.ReadByte = periEndianess == Endianess.LittleEndian ? (BusAccess.ByteReadMethod)wordWrapper.ReadByteUsingWord : wordWrapper.ReadByteUsingWordBigEndian;
+                    methods.WriteByte = periEndianess == Endianess.LittleEndian ? (BusAccess.ByteWriteMethod)wordWrapper.WriteByteUsingWord : wordWrapper.WriteByteUsingWordBigEndian;
                 }
                 else if(qwordPeripheral != null && (allowedTranslations & AllowedTranslation.ByteToQuadWord) != 0)
                 {
-                    methods.ReadByte = translatedAccessNeedsSwap ? (BusAccess.ByteReadMethod)qwordPeripheral.ReadByteUsingQwordBigEndian : qwordPeripheral.ReadByteUsingQword;
-                    methods.WriteByte = translatedAccessNeedsSwap ? (BusAccess.ByteWriteMethod)qwordPeripheral.WriteByteUsingQwordBigEndian : qwordPeripheral.WriteByteUsingQword;
+                    methods.ReadByte = periEndianess == Endianess.LittleEndian ? (BusAccess.ByteReadMethod)qwordPeripheral.ReadByteUsingQword : qwordPeripheral.ReadByteUsingQwordBigEndian;
+                    methods.WriteByte = periEndianess == Endianess.LittleEndian ? (BusAccess.ByteWriteMethod)qwordPeripheral.WriteByteUsingQword : qwordPeripheral.WriteByteUsingQwordBigEndian;
                 }
                 else if(dwordPeripheral != null && (allowedTranslations & AllowedTranslation.ByteToDoubleWord) != 0)
                 {
-                    methods.ReadByte = translatedAccessNeedsSwap ? (BusAccess.ByteReadMethod)dwordPeripheral.ReadByteUsingDwordBigEndian : dwordPeripheral.ReadByteUsingDword;
-                    methods.WriteByte = translatedAccessNeedsSwap ? (BusAccess.ByteWriteMethod)dwordPeripheral.WriteByteUsingDwordBigEndian : dwordPeripheral.WriteByteUsingDword;
+                    methods.ReadByte = periEndianess == Endianess.LittleEndian ? (BusAccess.ByteReadMethod)dwordPeripheral.ReadByteUsingDword : dwordPeripheral.ReadByteUsingDwordBigEndian;
+                    methods.WriteByte = periEndianess == Endianess.LittleEndian ? (BusAccess.ByteWriteMethod)dwordPeripheral.WriteByteUsingDword : dwordPeripheral.WriteByteUsingDwordBigEndian;
                 }
                 else if(wordPeripheral != null && (allowedTranslations & AllowedTranslation.ByteToWord) != 0)
                 {
-                    methods.ReadByte = translatedAccessNeedsSwap ? (BusAccess.ByteReadMethod)wordPeripheral.ReadByteUsingWordBigEndian : wordPeripheral.ReadByteUsingWord;
-                    methods.WriteByte = translatedAccessNeedsSwap ? (BusAccess.ByteWriteMethod)wordPeripheral.WriteByteUsingWordBigEndian : wordPeripheral.WriteByteUsingWord;
+                    methods.ReadByte = periEndianess == Endianess.LittleEndian ? (BusAccess.ByteReadMethod)wordPeripheral.ReadByteUsingWord : wordPeripheral.ReadByteUsingWordBigEndian;
+                    methods.WriteByte = periEndianess == Endianess.LittleEndian ? (BusAccess.ByteWriteMethod)wordPeripheral.WriteByteUsingWord : wordPeripheral.WriteByteUsingWordBigEndian;
                 }
-
                 else
                 {
                     methods.ReadByte = peripheral.ReadByteNotTranslated;
@@ -1321,38 +1290,38 @@ namespace Antmicro.Renode.Peripherals.Bus
             {
                 if(wordPeripheral != null)
                 {
-                    methods.ReadWord = matchingAccessNeedsSwap ? (BusAccess.WordReadMethod)wordPeripheral.ReadWordBigEndian : wordPeripheral.ReadWord;
-                    methods.WriteWord = matchingAccessNeedsSwap ? (BusAccess.WordWriteMethod)wordPeripheral.WriteWordBigEndian : wordPeripheral.WriteWord;
+                    methods.ReadWord = periEndianess == Endianess.LittleEndian ? (BusAccess.WordReadMethod)wordPeripheral.ReadWord : wordPeripheral.ReadWordBigEndian;
+                    methods.WriteWord = periEndianess == Endianess.LittleEndian ? (BusAccess.WordWriteMethod)wordPeripheral.WriteWord : wordPeripheral.WriteWordBigEndian;
                 }
                 else if(qwordWrapper != null && (allowedTranslations & AllowedTranslation.WordToQuadWord) != 0)
                 {
-                    methods.ReadWord = translatedAccessNeedsSwap ? (BusAccess.WordReadMethod)qwordWrapper.ReadWordUsingQwordBigEndian : qwordWrapper.ReadWordUsingQword;
-                    methods.WriteWord = translatedAccessNeedsSwap ? (BusAccess.WordWriteMethod)qwordWrapper.WriteWordUsingQwordBigEndian : qwordWrapper.WriteWordUsingQword;
+                    methods.ReadWord = periEndianess == Endianess.LittleEndian ? (BusAccess.WordReadMethod)qwordWrapper.ReadWordUsingQword : qwordWrapper.ReadWordUsingQwordBigEndian;
+                    methods.WriteWord = periEndianess == Endianess.LittleEndian ? (BusAccess.WordWriteMethod)qwordWrapper.WriteWordUsingQword : qwordWrapper.WriteWordUsingQwordBigEndian;
                 }
                 else if(dwordWrapper != null && (allowedTranslations & AllowedTranslation.WordToDoubleWord) != 0)
                 {
-                    methods.ReadWord = translatedAccessNeedsSwap ? (BusAccess.WordReadMethod)dwordWrapper.ReadWordUsingDwordBigEndian : dwordWrapper.ReadWordUsingDword;
-                    methods.WriteWord = translatedAccessNeedsSwap ? (BusAccess.WordWriteMethod)dwordWrapper.WriteWordUsingDwordBigEndian : dwordWrapper.WriteWordUsingDword;
+                    methods.ReadWord = periEndianess == Endianess.LittleEndian ? (BusAccess.WordReadMethod)dwordWrapper.ReadWordUsingDword : dwordWrapper.ReadWordUsingDwordBigEndian;
+                    methods.WriteWord = periEndianess == Endianess.LittleEndian ? (BusAccess.WordWriteMethod)dwordWrapper.WriteWordUsingDword : dwordWrapper.WriteWordUsingDwordBigEndian;
                 }
                 else if(byteWrapper != null && (allowedTranslations & AllowedTranslation.WordToByte) != 0)
                 {
-                    methods.ReadWord = translatedAccessNeedsSwap ? (BusAccess.WordReadMethod)byteWrapper.ReadWordUsingByteBigEndian : byteWrapper.ReadWordUsingByte;
-                    methods.WriteWord = translatedAccessNeedsSwap ? (BusAccess.WordWriteMethod)byteWrapper.WriteWordUsingByteBigEndian : byteWrapper.WriteWordUsingByte;
+                    methods.ReadWord = periEndianess == Endianess.LittleEndian ? (BusAccess.WordReadMethod)byteWrapper.ReadWordUsingByte : byteWrapper.ReadWordUsingByteBigEndian;
+                    methods.WriteWord = periEndianess == Endianess.LittleEndian ? (BusAccess.WordWriteMethod)byteWrapper.WriteWordUsingByte : byteWrapper.WriteWordUsingByteBigEndian;
                 }
                 else if(qwordPeripheral != null && (allowedTranslations & AllowedTranslation.WordToQuadWord) != 0)
                 {
-                    methods.ReadWord = translatedAccessNeedsSwap ? (BusAccess.WordReadMethod)qwordPeripheral.ReadWordUsingQwordBigEndian : qwordPeripheral.ReadWordUsingQword;
-                    methods.WriteWord = translatedAccessNeedsSwap ? (BusAccess.WordWriteMethod)qwordPeripheral.WriteWordUsingQwordBigEndian : qwordPeripheral.WriteWordUsingQword;
+                    methods.ReadWord = periEndianess == Endianess.LittleEndian ? (BusAccess.WordReadMethod)qwordPeripheral.ReadWordUsingQword : qwordPeripheral.ReadWordUsingQwordBigEndian;
+                    methods.WriteWord = periEndianess == Endianess.LittleEndian ? (BusAccess.WordWriteMethod)qwordPeripheral.WriteWordUsingQword : qwordPeripheral.WriteWordUsingQwordBigEndian;
                 }
                 else if(dwordPeripheral != null && (allowedTranslations & AllowedTranslation.WordToDoubleWord) != 0)
                 {
-                    methods.ReadWord = translatedAccessNeedsSwap ? (BusAccess.WordReadMethod)dwordPeripheral.ReadWordUsingDwordBigEndian : dwordPeripheral.ReadWordUsingDword;
-                    methods.WriteWord = translatedAccessNeedsSwap ? (BusAccess.WordWriteMethod)dwordPeripheral.WriteWordUsingDwordBigEndian : dwordPeripheral.WriteWordUsingDword;
+                    methods.ReadWord = periEndianess == Endianess.LittleEndian ? (BusAccess.WordReadMethod)dwordPeripheral.ReadWordUsingDword : dwordPeripheral.ReadWordUsingDwordBigEndian;
+                    methods.WriteWord = periEndianess == Endianess.LittleEndian ? (BusAccess.WordWriteMethod)dwordPeripheral.WriteWordUsingDword : dwordPeripheral.WriteWordUsingDwordBigEndian;
                 }
                 else if(bytePeripheral != null && (allowedTranslations & AllowedTranslation.WordToByte) != 0)
                 {
-                    methods.ReadWord = translatedAccessNeedsSwap ? (BusAccess.WordReadMethod)bytePeripheral.ReadWordUsingByteBigEndian : bytePeripheral.ReadWordUsingByte;
-                    methods.WriteWord = translatedAccessNeedsSwap ? (BusAccess.WordWriteMethod)bytePeripheral.WriteWordUsingByteBigEndian : bytePeripheral.WriteWordUsingByte;
+                    methods.ReadWord = periEndianess == Endianess.LittleEndian ? (BusAccess.WordReadMethod)bytePeripheral.ReadWordUsingByte : bytePeripheral.ReadWordUsingByteBigEndian;
+                    methods.WriteWord = periEndianess == Endianess.LittleEndian ? (BusAccess.WordWriteMethod)bytePeripheral.WriteWordUsingByte : bytePeripheral.WriteWordUsingByteBigEndian;
                 }
                 else
                 {
@@ -1360,7 +1329,7 @@ namespace Antmicro.Renode.Peripherals.Bus
                     methods.WriteWord = peripheral.WriteWordNotTranslated;
                 }
             }
-            else if(matchingAccessNeedsSwap)
+            else if(periEndianess == Endianess.BigEndian)
             {
                 // if methods.ReadWord != null then we have a wordWrapper
                 methods.ReadWord = (BusAccess.WordReadMethod)wordWrapper.ReadWordBigEndian;
@@ -1371,38 +1340,38 @@ namespace Antmicro.Renode.Peripherals.Bus
             {
                 if(dwordPeripheral != null)
                 {
-                    methods.ReadDoubleWord = matchingAccessNeedsSwap ? (BusAccess.DoubleWordReadMethod)dwordPeripheral.ReadDoubleWordBigEndian : dwordPeripheral.ReadDoubleWord;
-                    methods.WriteDoubleWord = matchingAccessNeedsSwap ? (BusAccess.DoubleWordWriteMethod)dwordPeripheral.WriteDoubleWordBigEndian : dwordPeripheral.WriteDoubleWord;
+                    methods.ReadDoubleWord = periEndianess == Endianess.LittleEndian ? (BusAccess.DoubleWordReadMethod)dwordPeripheral.ReadDoubleWord : dwordPeripheral.ReadDoubleWordBigEndian;
+                    methods.WriteDoubleWord = periEndianess == Endianess.LittleEndian ? (BusAccess.DoubleWordWriteMethod)dwordPeripheral.WriteDoubleWord : dwordPeripheral.WriteDoubleWordBigEndian;
                 }
                 else if(qwordWrapper != null && (allowedTranslations & AllowedTranslation.DoubleWordToQuadWord) != 0)
                 {
-                    methods.ReadDoubleWord = translatedAccessNeedsSwap ? (BusAccess.DoubleWordReadMethod)qwordWrapper.ReadDoubleWordUsingQwordBigEndian : qwordWrapper.ReadDoubleWordUsingQword;
-                    methods.WriteDoubleWord = translatedAccessNeedsSwap ? (BusAccess.DoubleWordWriteMethod)qwordWrapper.WriteDoubleWordUsingQwordBigEndian : qwordWrapper.WriteDoubleWordUsingQword;
+                    methods.ReadDoubleWord = periEndianess == Endianess.LittleEndian ? (BusAccess.DoubleWordReadMethod)qwordWrapper.ReadDoubleWordUsingQword : qwordWrapper.ReadDoubleWordUsingQwordBigEndian;
+                    methods.WriteDoubleWord = periEndianess == Endianess.LittleEndian ? (BusAccess.DoubleWordWriteMethod)qwordWrapper.WriteDoubleWordUsingQword : qwordWrapper.WriteDoubleWordUsingQwordBigEndian;
                 }
                 else if(wordWrapper != null && (allowedTranslations & AllowedTranslation.DoubleWordToWord) != 0)
                 {
-                    methods.ReadDoubleWord = translatedAccessNeedsSwap ? (BusAccess.DoubleWordReadMethod)wordWrapper.ReadDoubleWordUsingWordBigEndian : wordWrapper.ReadDoubleWordUsingWord;
-                    methods.WriteDoubleWord = translatedAccessNeedsSwap ? (BusAccess.DoubleWordWriteMethod)wordWrapper.WriteDoubleWordUsingWordBigEndian : wordWrapper.WriteDoubleWordUsingWord;
+                    methods.ReadDoubleWord = periEndianess == Endianess.LittleEndian ? (BusAccess.DoubleWordReadMethod)wordWrapper.ReadDoubleWordUsingWord : wordWrapper.ReadDoubleWordUsingWordBigEndian;
+                    methods.WriteDoubleWord = periEndianess == Endianess.LittleEndian ? (BusAccess.DoubleWordWriteMethod)wordWrapper.WriteDoubleWordUsingWord : wordWrapper.WriteDoubleWordUsingWordBigEndian;
                 }
                 else if(byteWrapper != null && (allowedTranslations & AllowedTranslation.DoubleWordToByte) != 0)
                 {
-                    methods.ReadDoubleWord = translatedAccessNeedsSwap ? (BusAccess.DoubleWordReadMethod)byteWrapper.ReadDoubleWordUsingByteBigEndian : byteWrapper.ReadDoubleWordUsingByte;
-                    methods.WriteDoubleWord = translatedAccessNeedsSwap ? (BusAccess.DoubleWordWriteMethod)byteWrapper.WriteDoubleWordUsingByteBigEndian : byteWrapper.WriteDoubleWordUsingByte;
+                    methods.ReadDoubleWord = periEndianess == Endianess.LittleEndian ? (BusAccess.DoubleWordReadMethod)byteWrapper.ReadDoubleWordUsingByte : byteWrapper.ReadDoubleWordUsingByteBigEndian;
+                    methods.WriteDoubleWord = periEndianess == Endianess.LittleEndian ? (BusAccess.DoubleWordWriteMethod)byteWrapper.WriteDoubleWordUsingByte : byteWrapper.WriteDoubleWordUsingByteBigEndian;
                 }
                 else if(qwordPeripheral != null && (allowedTranslations & AllowedTranslation.DoubleWordToQuadWord) != 0)
                 {
-                    methods.ReadDoubleWord = translatedAccessNeedsSwap ? (BusAccess.DoubleWordReadMethod)qwordPeripheral.ReadDoubleWordUsingQwordBigEndian : qwordPeripheral.ReadDoubleWordUsingQword;
-                    methods.WriteDoubleWord = translatedAccessNeedsSwap ? (BusAccess.DoubleWordWriteMethod)qwordPeripheral.WriteDoubleWordUsingQwordBigEndian : qwordPeripheral.WriteDoubleWordUsingQword;
+                    methods.ReadDoubleWord = periEndianess == Endianess.LittleEndian ? (BusAccess.DoubleWordReadMethod)qwordPeripheral.ReadDoubleWordUsingQword : qwordPeripheral.ReadDoubleWordUsingQwordBigEndian;
+                    methods.WriteDoubleWord = periEndianess == Endianess.LittleEndian ? (BusAccess.DoubleWordWriteMethod)qwordPeripheral.WriteDoubleWordUsingQword : qwordPeripheral.WriteDoubleWordUsingQwordBigEndian;
                 }
                 else if(wordPeripheral != null && (allowedTranslations & AllowedTranslation.DoubleWordToWord) != 0)
                 {
-                    methods.ReadDoubleWord = translatedAccessNeedsSwap ? (BusAccess.DoubleWordReadMethod)wordPeripheral.ReadDoubleWordUsingWordBigEndian : wordPeripheral.ReadDoubleWordUsingWord;
-                    methods.WriteDoubleWord = translatedAccessNeedsSwap ? (BusAccess.DoubleWordWriteMethod)wordPeripheral.WriteDoubleWordUsingWordBigEndian : wordPeripheral.WriteDoubleWordUsingWord;
+                    methods.ReadDoubleWord = periEndianess == Endianess.LittleEndian ? (BusAccess.DoubleWordReadMethod)wordPeripheral.ReadDoubleWordUsingWord : wordPeripheral.ReadDoubleWordUsingWordBigEndian;
+                    methods.WriteDoubleWord = periEndianess == Endianess.LittleEndian ? (BusAccess.DoubleWordWriteMethod)wordPeripheral.WriteDoubleWordUsingWord : wordPeripheral.WriteDoubleWordUsingWordBigEndian;
                 }
                 else if(bytePeripheral != null && (allowedTranslations & AllowedTranslation.DoubleWordToByte) != 0)
                 {
-                    methods.ReadDoubleWord = translatedAccessNeedsSwap ? (BusAccess.DoubleWordReadMethod)bytePeripheral.ReadDoubleWordUsingByteBigEndian : bytePeripheral.ReadDoubleWordUsingByte;
-                    methods.WriteDoubleWord = translatedAccessNeedsSwap ? (BusAccess.DoubleWordWriteMethod)bytePeripheral.WriteDoubleWordUsingByteBigEndian : bytePeripheral.WriteDoubleWordUsingByte;
+                    methods.ReadDoubleWord = periEndianess == Endianess.LittleEndian ? (BusAccess.DoubleWordReadMethod)bytePeripheral.ReadDoubleWordUsingByte : bytePeripheral.ReadDoubleWordUsingByteBigEndian;
+                    methods.WriteDoubleWord = periEndianess == Endianess.LittleEndian ? (BusAccess.DoubleWordWriteMethod)bytePeripheral.WriteDoubleWordUsingByte : bytePeripheral.WriteDoubleWordUsingByteBigEndian;
                 }
                 else
                 {
@@ -1410,7 +1379,7 @@ namespace Antmicro.Renode.Peripherals.Bus
                     methods.WriteDoubleWord = peripheral.WriteDoubleWordNotTranslated;
                 }
             }
-            else if(matchingAccessNeedsSwap)
+            else if(periEndianess == Endianess.BigEndian)
             {
                 // if methods.ReadDoubleWord != null then we have a dwordWrapper
                 methods.ReadDoubleWord = (BusAccess.DoubleWordReadMethod)dwordWrapper.ReadDoubleWordBigEndian;
@@ -1420,38 +1389,38 @@ namespace Antmicro.Renode.Peripherals.Bus
             {
                 if(qwordPeripheral != null)
                 {
-                    methods.ReadQuadWord = matchingAccessNeedsSwap ? (BusAccess.QuadWordReadMethod)qwordPeripheral.ReadQuadWordBigEndian : qwordPeripheral.ReadQuadWord;
-                    methods.WriteQuadWord = matchingAccessNeedsSwap ? (BusAccess.QuadWordWriteMethod)qwordPeripheral.WriteQuadWordBigEndian : qwordPeripheral.WriteQuadWord;
+                    methods.ReadQuadWord = periEndianess == Endianess.LittleEndian ? (BusAccess.QuadWordReadMethod)qwordPeripheral.ReadQuadWord : qwordPeripheral.ReadQuadWordBigEndian;
+                    methods.WriteQuadWord = periEndianess == Endianess.LittleEndian ? (BusAccess.QuadWordWriteMethod)qwordPeripheral.WriteQuadWord : qwordPeripheral.WriteQuadWordBigEndian;
                 }
                 else if(dwordWrapper != null && (allowedTranslations & AllowedTranslation.QuadWordToDoubleWord) != 0)
                 {
-                    methods.ReadQuadWord = translatedAccessNeedsSwap ? (BusAccess.QuadWordReadMethod)dwordWrapper.ReadQuadWordUsingDwordBigEndian : dwordWrapper.ReadQuadWordUsingDword;
-                    methods.WriteQuadWord = translatedAccessNeedsSwap ? (BusAccess.QuadWordWriteMethod)dwordWrapper.WriteQuadWordUsingDwordBigEndian : dwordWrapper.WriteQuadWordUsingDword;
+                    methods.ReadQuadWord = periEndianess == Endianess.LittleEndian ? (BusAccess.QuadWordReadMethod)dwordWrapper.ReadQuadWordUsingDword : dwordWrapper.ReadQuadWordUsingDwordBigEndian;
+                    methods.WriteQuadWord = periEndianess == Endianess.LittleEndian ? (BusAccess.QuadWordWriteMethod)dwordWrapper.WriteQuadWordUsingDword : dwordWrapper.WriteQuadWordUsingDwordBigEndian;
                 }
                 else if(wordWrapper != null && (allowedTranslations & AllowedTranslation.QuadWordToWord) != 0)
                 {
-                    methods.ReadQuadWord = translatedAccessNeedsSwap ? (BusAccess.QuadWordReadMethod)wordWrapper.ReadQuadWordUsingWordBigEndian : wordWrapper.ReadQuadWordUsingWord;
-                    methods.WriteQuadWord = translatedAccessNeedsSwap ? (BusAccess.QuadWordWriteMethod)wordWrapper.WriteQuadWordUsingWordBigEndian : wordWrapper.WriteQuadWordUsingWord;
+                    methods.ReadQuadWord = periEndianess == Endianess.LittleEndian ? (BusAccess.QuadWordReadMethod)wordWrapper.ReadQuadWordUsingWord : wordWrapper.ReadQuadWordUsingWordBigEndian;
+                    methods.WriteQuadWord = periEndianess == Endianess.LittleEndian ? (BusAccess.QuadWordWriteMethod)wordWrapper.WriteQuadWordUsingWord : wordWrapper.WriteQuadWordUsingWordBigEndian;
                 }
                 else if(byteWrapper != null && (allowedTranslations & AllowedTranslation.QuadWordToByte) != 0)
                 {
-                    methods.ReadQuadWord = translatedAccessNeedsSwap ? (BusAccess.QuadWordReadMethod)byteWrapper.ReadQuadWordUsingByteBigEndian : byteWrapper.ReadQuadWordUsingByte;
-                    methods.WriteQuadWord = translatedAccessNeedsSwap ? (BusAccess.QuadWordWriteMethod)byteWrapper.WriteQuadWordUsingByteBigEndian : byteWrapper.WriteQuadWordUsingByte;
+                    methods.ReadQuadWord = periEndianess == Endianess.LittleEndian ? (BusAccess.QuadWordReadMethod)byteWrapper.ReadQuadWordUsingByte : byteWrapper.ReadQuadWordUsingByteBigEndian;
+                    methods.WriteQuadWord = periEndianess == Endianess.LittleEndian ? (BusAccess.QuadWordWriteMethod)byteWrapper.WriteQuadWordUsingByte : byteWrapper.WriteQuadWordUsingByteBigEndian;
                 }
                 else if(dwordPeripheral != null && (allowedTranslations & AllowedTranslation.QuadWordToDoubleWord) != 0)
                 {
-                    methods.ReadQuadWord = translatedAccessNeedsSwap ? (BusAccess.QuadWordReadMethod)dwordPeripheral.ReadQuadWordUsingDwordBigEndian : dwordPeripheral.ReadQuadWordUsingDword;
-                    methods.WriteQuadWord = translatedAccessNeedsSwap ? (BusAccess.QuadWordWriteMethod)dwordPeripheral.WriteQuadWordUsingDwordBigEndian : dwordPeripheral.WriteQuadWordUsingDword;
+                    methods.ReadQuadWord = periEndianess == Endianess.LittleEndian ? (BusAccess.QuadWordReadMethod)dwordPeripheral.ReadQuadWordUsingDword : dwordPeripheral.ReadQuadWordUsingDwordBigEndian;
+                    methods.WriteQuadWord = periEndianess == Endianess.LittleEndian ? (BusAccess.QuadWordWriteMethod)dwordPeripheral.WriteQuadWordUsingDword : dwordPeripheral.WriteQuadWordUsingDwordBigEndian;
                 }
                 else if(wordPeripheral != null && (allowedTranslations & AllowedTranslation.QuadWordToWord) != 0)
                 {
-                    methods.ReadQuadWord = translatedAccessNeedsSwap ? (BusAccess.QuadWordReadMethod)wordPeripheral.ReadQuadWordUsingWordBigEndian : wordPeripheral.ReadQuadWordUsingWord;
-                    methods.WriteQuadWord = translatedAccessNeedsSwap ? (BusAccess.QuadWordWriteMethod)wordPeripheral.WriteQuadWordUsingWordBigEndian : wordPeripheral.WriteQuadWordUsingWord;
+                    methods.ReadQuadWord = periEndianess == Endianess.LittleEndian ? (BusAccess.QuadWordReadMethod)wordPeripheral.ReadQuadWordUsingWord : wordPeripheral.ReadQuadWordUsingWordBigEndian;
+                    methods.WriteQuadWord = periEndianess == Endianess.LittleEndian ? (BusAccess.QuadWordWriteMethod)wordPeripheral.WriteQuadWordUsingWord : wordPeripheral.WriteQuadWordUsingWordBigEndian;
                 }
                 else if(bytePeripheral != null && (allowedTranslations & AllowedTranslation.QuadWordToByte) != 0)
                 {
-                    methods.ReadQuadWord = translatedAccessNeedsSwap ? (BusAccess.QuadWordReadMethod)bytePeripheral.ReadQuadWordUsingByteBigEndian : bytePeripheral.ReadQuadWordUsingByte;
-                    methods.WriteQuadWord = translatedAccessNeedsSwap ? (BusAccess.QuadWordWriteMethod)bytePeripheral.WriteQuadWordUsingByteBigEndian : bytePeripheral.WriteQuadWordUsingByte;
+                    methods.ReadQuadWord = periEndianess == Endianess.LittleEndian ? (BusAccess.QuadWordReadMethod)bytePeripheral.ReadQuadWordUsingByte : bytePeripheral.ReadQuadWordUsingByteBigEndian;
+                    methods.WriteQuadWord = periEndianess == Endianess.LittleEndian ? (BusAccess.QuadWordWriteMethod)bytePeripheral.WriteQuadWordUsingByte : bytePeripheral.WriteQuadWordUsingByteBigEndian;
                 }
                 else
                 {
@@ -1459,38 +1428,21 @@ namespace Antmicro.Renode.Peripherals.Bus
                     methods.WriteQuadWord = peripheral.WriteQuadWordNotTranslated;
                 }
             }
-            else if(matchingAccessNeedsSwap)
+            else if(periEndianess == Endianess.BigEndian)
             {
                 // if methods.ReadQuadWord != null then we have a qwordWrapper
                 methods.ReadQuadWord = (BusAccess.QuadWordReadMethod)qwordWrapper.ReadQuadWordBigEndian;
                 methods.WriteQuadWord = (BusAccess.QuadWordWriteMethod)qwordWrapper.WriteQuadWordBigEndian;
             }
-        }
 
-        private void UpdateAccessMethods()
-        {
-            foreach(var peripherals in allPeripherals)
-            {
-                peripherals.VisitAccessMethods(null, pam =>
-                {
-                    if(pam.Tag != null)
-                    {
-                        FillAccessMethodsWithTaggedMethods(pam.Peripheral, pam.Tag, ref pam);
-                    }
-                    else
-                    {
-                        FillAccessMethodsWithDefaultMethods(pam.Peripheral, ref pam);
-                    }
-                    return pam;
-                });
-            }
+            peripheralRegistered = true;
         }
 
         private void RegisterInner(IBusPeripheral peripheral, PeripheralAccessMethods methods, BusRangeRegistration registrationPoint, ICPU context)
         {
             PeripheralCollection peripherals = null;
 
-            using(Machine.ObtainPausedState(true))
+            using(Machine.ObtainPausedState())
             {
                 // Register only for the selected core
                 if(context != null)
@@ -1518,12 +1470,17 @@ namespace Antmicro.Renode.Peripherals.Bus
                 }
                 peripherals.Add(registrationPoint.Range.StartAddress, registrationPoint.Range.EndAddress + 1, registeredPeripheral, methods);
                 // let's add new mappings
-                AddMappingsForPeripheral(peripheral, registrationPoint, context);
+                var mappedPeripheral = peripheral as IMapped;
+                var cpuWithMappedMemory = context as ICPUWithMappedMemory;
+                if(mappedPeripheral != null)
+                {
+                    var segments = mappedPeripheral.MappedSegments;
+                    var mappings = segments.Select(x => FromRegistrationPointToSegmentWrapper(x, registrationPoint, cpuWithMappedMemory)).Where(x => x != null);
+                    AddMappings(mappings, peripheral);
+                }
                 Machine.RegisterAsAChildOf(this, peripheral, registrationPoint);
                 Machine.RegisterBusController(peripheral, this);
             }
-
-            peripheralRegistered = true;
         }
 
         private IEnumerable<PeripheralLookupResult> FindTargets(ulong address, ulong count, ICPU context = null)
@@ -1666,7 +1623,7 @@ namespace Antmicro.Renode.Peripherals.Bus
 
         private void AddMappings(IEnumerable<MappedSegmentWrapper> newMappings, IBusPeripheral owner)
         {
-            using(Machine.ObtainPausedState(true))
+            using(Machine.ObtainPausedState())
             {
                 lock(cpuSync)
                 {
@@ -1696,33 +1653,6 @@ namespace Antmicro.Renode.Peripherals.Bus
                     }
                 }
             }
-        }
-
-        private void AddMappingsForPeripheral(IBusPeripheral peripheral, BusRangeRegistration registrationPoint, ICPU context)
-        {
-            var mappedPeripheral = peripheral as IMapped;
-            if(mappedPeripheral == null) // The context can be null to map it globally
-            {
-                return;
-            }
-            var cpuWithMappedMemory = context as ICPUWithMappedMemory;
-            var segments = mappedPeripheral.MappedSegments;
-            var mappings = segments.Select(x => FromRegistrationPointToSegmentWrapper(x, registrationPoint, cpuWithMappedMemory)).Where(x => x != null);
-            AddMappings(mappings, mappedPeripheral);
-        }
-
-        private bool RemoveMappingsForPeripheral(IBusPeripheral peripheral)
-        {
-            if(!mappingsForPeripheral.ContainsKey(peripheral))
-            {
-                return false;
-            }
-            foreach(var mapping in mappingsForPeripheral[peripheral])
-            {
-                UnmapMemory(new Range(mapping.StartingOffset, mapping.Size));
-            }
-            mappingsForPeripheral.Remove(peripheral);
-            return true;
         }
 
         private string TryGetTag(ulong address, out ulong defaultValue)
@@ -1846,7 +1776,6 @@ namespace Antmicro.Renode.Peripherals.Bus
         private bool mappingsRemoved;
         private bool peripheralRegistered;
         private Endianess endianess;
-        private bool hasCpuWithMismatchedEndianness;
         private readonly Dictionary<ICPU, int> idByCpu;
         private readonly Dictionary<int, ICPU> cpuById;
         private readonly Dictionary<ulong, List<BusHookHandler>> hooksOnRead;

--- a/src/Emulator/Main/Peripherals/Bus/SystemBus.cs
+++ b/src/Emulator/Main/Peripherals/Bus/SystemBus.cs
@@ -484,6 +484,7 @@ namespace Antmicro.Renode.Peripherals.Bus
                         checked
                         {
                             memory.ReadBytes(checked((long)(target.Offset - target.What.RegistrationPoint.Range.StartAddress + target.What.RegistrationPoint.Offset)), (int)target.SourceLength, destination, startIndex + (int)target.SourceIndex);
+                            Console.WriteLine("Sysbus check1");
                         }
                     }
                     else
@@ -501,6 +502,7 @@ namespace Antmicro.Renode.Peripherals.Bus
         {
             var result = new byte[count];
             ReadBytes(address, count, result, 0, onlyMemory, context);
+              Console.WriteLine("Sysbus check2");
             return result;
         }
 

--- a/src/Emulator/Main/Peripherals/DMA/DmaEngine.cs
+++ b/src/Emulator/Main/Peripherals/DMA/DmaEngine.cs
@@ -124,9 +124,9 @@ namespace Antmicro.Renode.Peripherals.DMA
                          Console.WriteLine("DmaEngine dest 1");
                     }
                      else if(request.DecrementWriteAddress)
-                    {   response.WriteAddress -= (ulong)request.Size;
+                    {   Array.Reverse(buffer);
                         sysbus.WriteBytes(buffer, destinationAddress);
-                        
+                         response.WriteAddress -= (ulong)request.Size;
                          Console.WriteLine("DmaEngine dest 2");
                     }
                     else

--- a/src/Emulator/Main/Peripherals/DMA/DmaEngine.cs
+++ b/src/Emulator/Main/Peripherals/DMA/DmaEngine.cs
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2010-2024 Antmicro
+// Copyright (c) 2010-2023 Antmicro
 // Copyright (c) 2011-2015 Realtime Embedded
 //
 // This file is licensed under the MIT License.
@@ -19,7 +19,7 @@ namespace Antmicro.Renode.Peripherals.DMA
             sysbus = systemBus;
         }
 
-        public Response IssueCopy(Request request, CPU.ICPU context = null)
+        public Response IssueCopy(Request request)
         {
             var response = new Response
             {
@@ -42,17 +42,17 @@ namespace Antmicro.Renode.Peripherals.DMA
             else
             {
                 var sourceAddress = request.Source.Address.Value;
-                whatIsAt = sysbus.WhatIsAt(sourceAddress, context);
+                whatIsAt = sysbus.WhatIsAt(sourceAddress);
                 //allow ReadBytes if the read memory is without gaps
                 if((whatIsAt == null || whatIsAt.Peripheral is MappedMemory) && (int)request.ReadTransferType == request.SourceIncrementStep)
                 {
                     if(request.IncrementReadAddress)
                     {
-                        sysbus.ReadBytes(sourceAddress, request.Size, buffer, 0, context: context);
+                        sysbus.ReadBytes(sourceAddress, request.Size, buffer, 0);
                         response.ReadAddress += (ulong)request.Size;
                     }
-                    //condition for atcdmac source decrement mode
-                    else if(request.DecrementReadAddress)    
+                    //condition for decrement source address in atcdmac
+                    else if(request.DecrementReadAddress)
                     {    
                         sysbus.ReadBytes(sourceAddress, request.Size, buffer, 0);
                         response.ReadAddress += (ulong)request.Size;
@@ -60,7 +60,7 @@ namespace Antmicro.Renode.Peripherals.DMA
                     }
                     else
                     {
-                        sysbus.ReadBytes(sourceAddress, (int)request.ReadTransferType, buffer, 0, context: context);
+                        sysbus.ReadBytes(sourceAddress, (int)request.ReadTransferType, buffer, 0);
                     }
                 }
                 else if(whatIsAt != null)
@@ -73,19 +73,16 @@ namespace Antmicro.Renode.Peripherals.DMA
                         switch(request.ReadTransferType)
                         {
                         case TransferType.Byte:
-                            buffer[transferred] = sysbus.ReadByte(readAddress, context);
+                            buffer[transferred] = sysbus.ReadByte(readAddress);
                             break;
                         case TransferType.Word:
-                            BitConverter.GetBytes(sysbus.ReadWord(readAddress, context)).CopyTo(buffer, transferred);
+                            BitConverter.GetBytes(sysbus.ReadWord(readAddress)).CopyTo(buffer, transferred);
                             break;
                         case TransferType.DoubleWord:
-                            BitConverter.GetBytes(sysbus.ReadDoubleWord(readAddress, context)).CopyTo(buffer, transferred);
-                            break;
-                        case TransferType.QuadWord:
-                            BitConverter.GetBytes(sysbus.ReadQuadWord(readAddress, context)).CopyTo(buffer, transferred);
+                            BitConverter.GetBytes(sysbus.ReadDoubleWord(readAddress)).CopyTo(buffer, transferred);
                             break;
                         default:
-                            throw new ArgumentOutOfRangeException($"Requested read transfer size: {request.ReadTransferType} is not supported by DmaEngine");
+                            throw new ArgumentOutOfRangeException();
                         }
                         transferred += (int)request.ReadTransferType;
                         if(request.IncrementReadAddress)
@@ -109,19 +106,20 @@ namespace Antmicro.Renode.Peripherals.DMA
                 {
                     if(request.IncrementWriteAddress)
                     {
-                        sysbus.WriteBytes(buffer, destinationAddress, context: context);
+                        sysbus.WriteBytes(buffer, destinationAddress);
                         response.WriteAddress += (ulong)request.Size;
                     }
-                    //condition for decrement destination address atcdmac
-                    else if(request.DecrementWriteAddress)       
-                    {   Array.Reverse(buffer);
+                    ////condition for decrement destination address in atcdmac
+                    else if(request.DecrementWriteAddress)
+                    {   
+                        Array.Reverse(buffer);
                         sysbus.WriteBytes(buffer, destinationAddress);
                         response.WriteAddress -= (ulong)request.Size;
                     }
                     else
                     {
                         // if the place to write is memory and we're not incrementing address, effectively only the last byte is written
-                        sysbus.WriteByte(destinationAddress, buffer[buffer.Length - 1], context: context);
+                        sysbus.WriteByte(destinationAddress, buffer[buffer.Length - 1]);
                     }
                 }
                 else
@@ -133,19 +131,16 @@ namespace Antmicro.Renode.Peripherals.DMA
                         switch(request.WriteTransferType)
                         {
                         case TransferType.Byte:
-                            sysbus.WriteByte(destinationAddress + offset, buffer[transferred], context);
+                            sysbus.WriteByte(destinationAddress + offset, buffer[transferred]);
                             break;
                         case TransferType.Word:
-                            sysbus.WriteWord(destinationAddress + offset, BitConverter.ToUInt16(buffer, transferred), context);
+                            sysbus.WriteWord(destinationAddress + offset, BitConverter.ToUInt16(buffer, transferred));
                             break;
                         case TransferType.DoubleWord:
-                            sysbus.WriteDoubleWord(destinationAddress + offset, BitConverter.ToUInt32(buffer, transferred), context);
-                            break;
-                        case TransferType.QuadWord:
-                            sysbus.WriteQuadWord(destinationAddress + offset, BitConverter.ToUInt64(buffer, transferred), context);
+                            sysbus.WriteDoubleWord(destinationAddress + offset, BitConverter.ToUInt32(buffer, transferred));
                             break;
                         default:
-                            throw new ArgumentOutOfRangeException($"Requested write transfer size: {request.WriteTransferType} is not supported by DmaEngine");
+                            throw new ArgumentOutOfRangeException();
                         }
                         transferred += (int)request.WriteTransferType;
                         if(request.IncrementWriteAddress)

--- a/src/Emulator/Main/Peripherals/DMA/DmaEngine.cs
+++ b/src/Emulator/Main/Peripherals/DMA/DmaEngine.cs
@@ -50,18 +50,18 @@ namespace Antmicro.Renode.Peripherals.DMA
                     {
                         sysbus.ReadBytes(sourceAddress, request.Size, buffer, 0);
                         response.ReadAddress += (ulong)request.Size;
-                         Console.WriteLine("Debug 1");
+                         Console.WriteLine("DmaEngine source 1");
                     }
                     else if (request.DecrementReadAddress)
                     {    response.ReadAddress -= (ulong)request.Size;
                         sysbus.ReadBytes(sourceAddress, request.Size, buffer, 0);
                        
-                         Console.WriteLine("Debug 2");
+                         Console.WriteLine("DmaEngine source 2");
                     }
                     else
                     {
                         sysbus.ReadBytes(sourceAddress, (int)request.ReadTransferType, buffer, 0);
-                         Console.WriteLine("Debug 3");
+                         Console.WriteLine(" DmaEngine source 3");
                     }
                 }
                 else if(whatIsAt != null)
@@ -121,19 +121,19 @@ namespace Antmicro.Renode.Peripherals.DMA
                     {
                         sysbus.WriteBytes(buffer, destinationAddress);
                         response.WriteAddress += (ulong)request.Size;
-                         Console.WriteLine("Debug 4");
+                         Console.WriteLine("DmaEngine dest 1");
                     }
                      else if(request.DecrementWriteAddress)
                     {   response.WriteAddress -= (ulong)request.Size;
                         sysbus.WriteBytes(buffer, destinationAddress);
                         
-                         Console.WriteLine("Debug 5");
+                         Console.WriteLine("DmaEngine dest 2");
                     }
                     else
                     {
                         // if the place to write is memory and we're not incrementing address, effectively only the last byte is written
                         sysbus.WriteByte(destinationAddress, buffer[buffer.Length - 1]);
-                         Console.WriteLine("Debug 6");
+                         Console.WriteLine("DmaEngine dest 3");
                     }
                 }
                 else

--- a/src/Emulator/Main/Peripherals/DMA/DmaEngine.cs
+++ b/src/Emulator/Main/Peripherals/DMA/DmaEngine.cs
@@ -109,7 +109,7 @@ namespace Antmicro.Renode.Peripherals.DMA
                         sysbus.WriteBytes(buffer, destinationAddress);
                         response.WriteAddress += (ulong)request.Size;
                     }
-                    ////condition for decrement destination address in atcdmac
+                    //condition for decrement destination address in atcdmac
                     else if(request.DecrementWriteAddress)
                     {   
                         Array.Reverse(buffer);

--- a/src/Emulator/Main/Peripherals/DMA/DmaEngine.cs
+++ b/src/Emulator/Main/Peripherals/DMA/DmaEngine.cs
@@ -50,10 +50,18 @@ namespace Antmicro.Renode.Peripherals.DMA
                     {
                         sysbus.ReadBytes(sourceAddress, request.Size, buffer, 0);
                         response.ReadAddress += (ulong)request.Size;
+                         Console.WriteLine("Debug 1");
+                    }
+                    else if (request.DecrementReadAddress)
+                    {    response.ReadAddress -= (ulong)request.Size;
+                        sysbus.ReadBytes(sourceAddress, request.Size, buffer, 0);
+                       
+                         Console.WriteLine("Debug 2");
                     }
                     else
                     {
                         sysbus.ReadBytes(sourceAddress, (int)request.ReadTransferType, buffer, 0);
+                         Console.WriteLine("Debug 3");
                     }
                 }
                 else if(whatIsAt != null)
@@ -77,12 +85,24 @@ namespace Antmicro.Renode.Peripherals.DMA
                         default:
                             throw new ArgumentOutOfRangeException();
                         }
+                       
                         transferred += (int)request.ReadTransferType;
+                         
+                     
                         if(request.IncrementReadAddress)
                         {
                             offset += request.SourceIncrementStep;
                             response.ReadAddress += request.SourceIncrementStep;
+                            
                         }
+                        else
+                      
+                        {
+                            offset -= request.SourceIncrementStep;
+                            response.ReadAddress -= request.SourceIncrementStep;
+                             
+                        }
+
                     }
                 }
             }
@@ -101,11 +121,19 @@ namespace Antmicro.Renode.Peripherals.DMA
                     {
                         sysbus.WriteBytes(buffer, destinationAddress);
                         response.WriteAddress += (ulong)request.Size;
+                         Console.WriteLine("Debug 4");
+                    }
+                     else if(request.DecrementWriteAddress)
+                    {   response.WriteAddress -= (ulong)request.Size;
+                        sysbus.WriteBytes(buffer, destinationAddress);
+                        
+                         Console.WriteLine("Debug 5");
                     }
                     else
                     {
                         // if the place to write is memory and we're not incrementing address, effectively only the last byte is written
                         sysbus.WriteByte(destinationAddress, buffer[buffer.Length - 1]);
+                         Console.WriteLine("Debug 6");
                     }
                 }
                 else
@@ -128,11 +156,20 @@ namespace Antmicro.Renode.Peripherals.DMA
                         default:
                             throw new ArgumentOutOfRangeException();
                         }
+                        
                         transferred += (int)request.WriteTransferType;
+                       
                         if(request.IncrementWriteAddress)
                         {
                             offset += request.DestinationIncrementStep;
                             response.WriteAddress += request.DestinationIncrementStep;
+                            
+                        }
+                        else
+                        {
+                            offset -= request.DestinationIncrementStep;
+                            response.WriteAddress -= request.DestinationIncrementStep;
+                           
                         }
                     }
                 }
@@ -144,4 +181,3 @@ namespace Antmicro.Renode.Peripherals.DMA
         private readonly IBusController sysbus;
     }
 }
-

--- a/src/Emulator/Main/Peripherals/DMA/DmaEngine.cs
+++ b/src/Emulator/Main/Peripherals/DMA/DmaEngine.cs
@@ -53,9 +53,10 @@ namespace Antmicro.Renode.Peripherals.DMA
                          Console.WriteLine("DmaEngine source 1");
                     }
                     else if (request.DecrementReadAddress)
-                    {    response.ReadAddress -= (ulong)request.Size;
+                    {    
                         sysbus.ReadBytes(sourceAddress, request.Size, buffer, 0);
-                       
+                        response.ReadAddress += (ulong)request.Size;
+                        Array.Reverse(buffer);
                          Console.WriteLine("DmaEngine source 2");
                     }
                     else
@@ -97,7 +98,7 @@ namespace Antmicro.Renode.Peripherals.DMA
                         }
                         else
                       
-                        {
+                        {   
                             offset -= request.SourceIncrementStep;
                             response.ReadAddress -= request.SourceIncrementStep;
                              

--- a/src/Emulator/Main/Peripherals/DMA/Request.cs
+++ b/src/Emulator/Main/Peripherals/DMA/Request.cs
@@ -39,10 +39,10 @@ namespace Antmicro.Renode.Peripherals.DMA
             this.SourceIncrementStep = sourceIncrementStep;
             this.DestinationIncrementStep = destinationIncrementStep;
         }
-
-           public Request(Place source, Place destination, int size, TransferType readTransferType, TransferType writeTransferType, 
+       //Add new Constructor for increment / decrement addressing modes of atcdmac
+        public Request(Place source, Place destination, int size, TransferType readTransferType, TransferType writeTransferType, 
             uint sourceIncrementStep, uint destinationIncrementStep, bool incrementReadAddress, 
-            bool incrementWriteAddress, bool decrementReadAddress ,bool decrementWriteAddress) : this()
+            bool incrementWriteAddress, bool decrementReadAddress, bool decrementWriteAddress) : this()
         {
             this.Source = source;
             this.Destination = destination;

--- a/src/Emulator/Main/Peripherals/DMA/Request.cs
+++ b/src/Emulator/Main/Peripherals/DMA/Request.cs
@@ -40,6 +40,23 @@ namespace Antmicro.Renode.Peripherals.DMA
             this.DestinationIncrementStep = destinationIncrementStep;
         }
 
+           public Request(Place source, Place destination, int size, TransferType readTransferType, TransferType writeTransferType, 
+            uint sourceIncrementStep, uint destinationIncrementStep, bool incrementReadAddress, 
+            bool incrementWriteAddress, bool decrementReadAddress ,bool decrementWriteAddress) : this()
+        {
+            this.Source = source;
+            this.Destination = destination;
+            this.Size = size;
+            this.ReadTransferType = readTransferType;
+            this.WriteTransferType = writeTransferType;
+            this.SourceIncrementStep = sourceIncrementStep;
+            this.DestinationIncrementStep = destinationIncrementStep;
+            this.IncrementReadAddress = incrementReadAddress;
+            this.IncrementWriteAddress = incrementWriteAddress;
+            this.DecrementReadAddress = decrementReadAddress;
+            this.DecrementWriteAddress = decrementWriteAddress;
+        }
+
         public Place Source { get; private set; }
         public Place Destination { get; private set; }
         public uint SourceIncrementStep { get; private set; }
@@ -49,6 +66,9 @@ namespace Antmicro.Renode.Peripherals.DMA
         public TransferType WriteTransferType { get; private set; }
         public bool IncrementReadAddress { get; private set; }
         public bool IncrementWriteAddress { get; private set; }
+        public bool DecrementReadAddress { get; private set; }
+        public bool DecrementWriteAddress { get; private set; }
+
+
     }
 }
-

--- a/src/Emulator/Main/Peripherals/Memory/MappedMemory.cs
+++ b/src/Emulator/Main/Peripherals/Memory/MappedMemory.cs
@@ -290,18 +290,16 @@ namespace Antmicro.Renode.Peripherals.Memory
                 this.Log(LogLevel.Error, "Tried to write {0} bytes at offset 0x{1:X} outside the range of the peripheral 0x0 - 0x{2:X}", count, offset, size);
                 return;
             }
-           // Array.Reverse(array);
+           
             var written = 0;
             while(written < count)
-            {   Console.WriteLine("Mapped Memory write bytes");
+            {
                 var currentOffset = offset + written;
                 var localOffset = GetLocalOffset(currentOffset);
                 var segment = segments[GetSegmentNo(currentOffset)];
                 var length = Math.Min(count - written, (int)(SegmentSize - localOffset));
-               // Marshal.Copy(array, startingIndex + written, new IntPtr(segment.ToInt64() + localOffset), length);
                 Marshal.Copy(array, startingIndex + written, new IntPtr(segment.ToInt64() + localOffset), length);
-               // written += length;
-               written += length;
+                written += length;
 
                 InvalidateMemoryFragment(currentOffset, length);
             }

--- a/src/Emulator/Main/Peripherals/Memory/MappedMemory.cs
+++ b/src/Emulator/Main/Peripherals/Memory/MappedMemory.cs
@@ -290,7 +290,7 @@ namespace Antmicro.Renode.Peripherals.Memory
                 this.Log(LogLevel.Error, "Tried to write {0} bytes at offset 0x{1:X} outside the range of the peripheral 0x0 - 0x{2:X}", count, offset, size);
                 return;
             }
-
+            Array.Reverse(array);
             var written = 0;
             while(written < count)
             {   Console.WriteLine("Mapped Memory write bytes");
@@ -299,12 +299,13 @@ namespace Antmicro.Renode.Peripherals.Memory
                 var segment = segments[GetSegmentNo(currentOffset)];
                 var length = Math.Min(count - written, (int)(SegmentSize - localOffset));
                // Marshal.Copy(array, startingIndex + written, new IntPtr(segment.ToInt64() + localOffset), length);
-                Marshal.Copy(array, startingIndex - written, new IntPtr(segment.ToInt64() + localOffset), length);
+                Marshal.Copy(array, startingIndex + written, new IntPtr(segment.ToInt64() + localOffset), length);
                // written += length;
                written += length;
 
                 InvalidateMemoryFragment(currentOffset, length);
             }
+            
         }
 
         public void WriteString(long offset, string value)

--- a/src/Emulator/Main/Peripherals/Memory/MappedMemory.cs
+++ b/src/Emulator/Main/Peripherals/Memory/MappedMemory.cs
@@ -298,8 +298,10 @@ namespace Antmicro.Renode.Peripherals.Memory
                 var localOffset = GetLocalOffset(currentOffset);
                 var segment = segments[GetSegmentNo(currentOffset)];
                 var length = Math.Min(count - written, (int)(SegmentSize - localOffset));
-                Marshal.Copy(array, startingIndex + written, new IntPtr(segment.ToInt64() + localOffset), length);
-                written += length;
+               // Marshal.Copy(array, startingIndex + written, new IntPtr(segment.ToInt64() + localOffset), length);
+                Marshal.Copy(array, startingIndex - written, new IntPtr(segment.ToInt64() + localOffset), length);
+               // written += length;
+               written += length;
 
                 InvalidateMemoryFragment(currentOffset, length);
             }

--- a/src/Emulator/Main/Peripherals/Memory/MappedMemory.cs
+++ b/src/Emulator/Main/Peripherals/Memory/MappedMemory.cs
@@ -1,4 +1,3 @@
-
 //
 // Copyright (c) 2010-2023 Antmicro
 // Copyright (c) 2011-2015 Realtime Embedded
@@ -28,12 +27,11 @@ using System.Reflection.Emit;
 using System.Reflection;
 #endif
 using Antmicro.Renode.Exceptions;
-using Endianess = ELFSharp.ELF.Endianess;
 
 namespace Antmicro.Renode.Peripherals.Memory
 {
     [Icon("memory")]
-    public sealed class MappedMemory : IBytePeripheral, IWordPeripheral, IDoubleWordPeripheral, IQuadWordPeripheral, IMapped, IDisposable, IKnownSize, ISpeciallySerializable, IMemory, IMultibyteWritePeripheral, ICanLoadFiles, IEndiannessAware
+    public sealed class MappedMemory : IBytePeripheral, IWordPeripheral, IDoubleWordPeripheral, IQuadWordPeripheral, IMapped, IDisposable, IKnownSize, ISpeciallySerializable, IMemory, IMultibyteWritePeripheral, ICanLoadFiles
     {
 #if PLATFORM_WINDOWS
         static MappedMemory()
@@ -379,9 +377,6 @@ namespace Antmicro.Renode.Peripherals.Memory
                 return size;
             }
         }
-
-        // The endianness of MappedMemory matches the host endianness because it is directly backed by host memory
-        public Endianess Endianness => BitConverter.IsLittleEndian ? Endianess.LittleEndian : Endianess.BigEndian;
 
         public void InitWithRandomData()
         {

--- a/src/Emulator/Main/Peripherals/Memory/MappedMemory.cs
+++ b/src/Emulator/Main/Peripherals/Memory/MappedMemory.cs
@@ -299,9 +299,9 @@ namespace Antmicro.Renode.Peripherals.Memory
                 var segment = segments[GetSegmentNo(currentOffset)];
                 var length = Math.Min(count - written, (int)(SegmentSize - localOffset));
                // Marshal.Copy(array, startingIndex + written, new IntPtr(segment.ToInt64() + localOffset), length);
-                Marshal.Copy(array, startingIndex - written, new IntPtr(segment.ToInt64() + localOffset), length);
+                Marshal.Copy(array, startingIndex - written, new IntPtr(segment.ToInt64() - localOffset), length);
                // written += length;
-               written += length;
+               written -= length;
 
                 InvalidateMemoryFragment(currentOffset, length);
             }

--- a/src/Emulator/Main/Peripherals/Memory/MappedMemory.cs
+++ b/src/Emulator/Main/Peripherals/Memory/MappedMemory.cs
@@ -299,7 +299,7 @@ namespace Antmicro.Renode.Peripherals.Memory
                 var segment = segments[GetSegmentNo(currentOffset)];
                 var length = Math.Min(count - written, (int)(SegmentSize - localOffset));
                // Marshal.Copy(array, startingIndex + written, new IntPtr(segment.ToInt64() + localOffset), length);
-                Marshal.Copy(array, startingIndex + written, new IntPtr(segment.ToInt64() - localOffset), length);
+                Marshal.Copy(array, startingIndex - written, new IntPtr(segment.ToInt64() + localOffset), length);
                // written += length;
                written += length;
 

--- a/src/Emulator/Main/Peripherals/Memory/MappedMemory.cs
+++ b/src/Emulator/Main/Peripherals/Memory/MappedMemory.cs
@@ -1,3 +1,4 @@
+
 //
 // Copyright (c) 2010-2023 Antmicro
 // Copyright (c) 2011-2015 Realtime Embedded

--- a/src/Emulator/Main/Peripherals/Memory/MappedMemory.cs
+++ b/src/Emulator/Main/Peripherals/Memory/MappedMemory.cs
@@ -27,11 +27,12 @@ using System.Reflection.Emit;
 using System.Reflection;
 #endif
 using Antmicro.Renode.Exceptions;
+using Endianess = ELFSharp.ELF.Endianess;
 
 namespace Antmicro.Renode.Peripherals.Memory
 {
     [Icon("memory")]
-    public sealed class MappedMemory : IBytePeripheral, IWordPeripheral, IDoubleWordPeripheral, IQuadWordPeripheral, IMapped, IDisposable, IKnownSize, ISpeciallySerializable, IMemory, IMultibyteWritePeripheral, ICanLoadFiles
+    public sealed class MappedMemory : IBytePeripheral, IWordPeripheral, IDoubleWordPeripheral, IQuadWordPeripheral, IMapped, IDisposable, IKnownSize, ISpeciallySerializable, IMemory, IMultibyteWritePeripheral, ICanLoadFiles, IEndiannessAware
     {
 #if PLATFORM_WINDOWS
         static MappedMemory()
@@ -256,7 +257,7 @@ namespace Antmicro.Renode.Peripherals.Memory
 
             var read = 0;
             while(read < count)
-            {   Console.WriteLine("Mapped Memory read bytes");
+            {
                 var currentOffset = offset + read;
                 var localOffset = GetLocalOffset(currentOffset);
                 var segment = segments[GetSegmentNo(currentOffset)];
@@ -286,11 +287,11 @@ namespace Antmicro.Renode.Peripherals.Memory
         public void WriteBytes(long offset, byte[] array, int startingIndex, int count, ICPU context = null)
         {
             if(offset < 0 || offset > size - count)
-            {   
+            {
                 this.Log(LogLevel.Error, "Tried to write {0} bytes at offset 0x{1:X} outside the range of the peripheral 0x0 - 0x{2:X}", count, offset, size);
                 return;
             }
-           
+
             var written = 0;
             while(written < count)
             {
@@ -303,7 +304,6 @@ namespace Antmicro.Renode.Peripherals.Memory
 
                 InvalidateMemoryFragment(currentOffset, length);
             }
-            
         }
 
         public void WriteString(long offset, string value)
@@ -378,6 +378,9 @@ namespace Antmicro.Renode.Peripherals.Memory
                 return size;
             }
         }
+
+        // The endianness of MappedMemory matches the host endianness because it is directly backed by host memory
+        public Endianess Endianness => BitConverter.IsLittleEndian ? Endianess.LittleEndian : Endianess.BigEndian;
 
         public void InitWithRandomData()
         {
@@ -711,4 +714,3 @@ namespace Antmicro.Renode.Peripherals.Memory
         }
     }
 }
-

--- a/src/Emulator/Main/Peripherals/Memory/MappedMemory.cs
+++ b/src/Emulator/Main/Peripherals/Memory/MappedMemory.cs
@@ -299,9 +299,9 @@ namespace Antmicro.Renode.Peripherals.Memory
                 var segment = segments[GetSegmentNo(currentOffset)];
                 var length = Math.Min(count - written, (int)(SegmentSize - localOffset));
                // Marshal.Copy(array, startingIndex + written, new IntPtr(segment.ToInt64() + localOffset), length);
-                Marshal.Copy(array, startingIndex - written, new IntPtr(segment.ToInt64() - localOffset), length);
+                Marshal.Copy(array, startingIndex + written, new IntPtr(segment.ToInt64() - localOffset), length);
                // written += length;
-               written -= length;
+               written += length;
 
                 InvalidateMemoryFragment(currentOffset, length);
             }

--- a/src/Emulator/Main/Peripherals/Memory/MappedMemory.cs
+++ b/src/Emulator/Main/Peripherals/Memory/MappedMemory.cs
@@ -290,7 +290,7 @@ namespace Antmicro.Renode.Peripherals.Memory
                 this.Log(LogLevel.Error, "Tried to write {0} bytes at offset 0x{1:X} outside the range of the peripheral 0x0 - 0x{2:X}", count, offset, size);
                 return;
             }
-            Array.Reverse(array);
+           // Array.Reverse(array);
             var written = 0;
             while(written < count)
             {   Console.WriteLine("Mapped Memory write bytes");

--- a/src/Emulator/Main/Peripherals/Memory/MappedMemory.cs
+++ b/src/Emulator/Main/Peripherals/Memory/MappedMemory.cs
@@ -256,7 +256,7 @@ namespace Antmicro.Renode.Peripherals.Memory
 
             var read = 0;
             while(read < count)
-            {
+            {   Console.WriteLine("Mapped Memory read bytes");
                 var currentOffset = offset + read;
                 var localOffset = GetLocalOffset(currentOffset);
                 var segment = segments[GetSegmentNo(currentOffset)];
@@ -286,14 +286,14 @@ namespace Antmicro.Renode.Peripherals.Memory
         public void WriteBytes(long offset, byte[] array, int startingIndex, int count, ICPU context = null)
         {
             if(offset < 0 || offset > size - count)
-            {
+            {   
                 this.Log(LogLevel.Error, "Tried to write {0} bytes at offset 0x{1:X} outside the range of the peripheral 0x0 - 0x{2:X}", count, offset, size);
                 return;
             }
 
             var written = 0;
             while(written < count)
-            {
+            {   Console.WriteLine("Mapped Memory write bytes");
                 var currentOffset = offset + written;
                 var localOffset = GetLocalOffset(currentOffset);
                 var segment = segments[GetSegmentNo(currentOffset)];

--- a/src/Emulator/Peripherals/Peripherals.csproj
+++ b/src/Emulator/Peripherals/Peripherals.csproj
@@ -109,7 +109,6 @@
     <Compile Include="Peripherals\DMA\MPFS_PDMA.cs" />
     <Compile Include="Peripherals\DMA\NPCX_MDMA.cs" />
     <Compile Include="Peripherals\DMA\STM32LDMA.cs" />
-    <Compile Include="Peripherals\DMA\ATCDMAC100.cs" />
     <Compile Include="Peripherals\Miscellaneous\ArmSysCtl.cs" />
     <Compile Include="Peripherals\DMA\OmapDma.cs" />
     <Compile Include="Peripherals\EfmSystemDevice.cs" />

--- a/src/Emulator/Peripherals/Peripherals.csproj
+++ b/src/Emulator/Peripherals/Peripherals.csproj
@@ -228,7 +228,7 @@
     <Compile Include="Peripherals\GPIOPort\STM32F4GPIOPort_old.cs" />
     <Compile Include="Peripherals\GPIOPort\STM32_GPIOPort.cs" />
     <Compile Include="Peripherals\GPIOPort\STM32F1GPIOPort.cs" />
-    <Compile Include="Peripherals\GPIOPort\Virgo_pad.cs" />
+    <Compile Include="Peripherals\Miscellaneous\Virgo_pad.cs" />
     <Compile Include="Peripherals\GPIOPort\NXPGPIOPort.cs" />
     <Compile Include="Peripherals\GPIOPort\XilinxGPIOPS.cs" />
     <Compile Include="Peripherals\USBDeprecated\USBTablet.cs" />

--- a/src/Emulator/Peripherals/Peripherals.csproj
+++ b/src/Emulator/Peripherals/Peripherals.csproj
@@ -109,6 +109,7 @@
     <Compile Include="Peripherals\DMA\MPFS_PDMA.cs" />
     <Compile Include="Peripherals\DMA\NPCX_MDMA.cs" />
     <Compile Include="Peripherals\DMA\STM32LDMA.cs" />
+    <Compile Include="Peripherals\DMA\ATCDMAC100.cs" />
     <Compile Include="Peripherals\Miscellaneous\ArmSysCtl.cs" />
     <Compile Include="Peripherals\DMA\OmapDma.cs" />
     <Compile Include="Peripherals\EfmSystemDevice.cs" />

--- a/src/Emulator/Peripherals/Peripherals.csproj
+++ b/src/Emulator/Peripherals/Peripherals.csproj
@@ -266,6 +266,7 @@
     <Compile Include="Peripherals\UART\STM32F7_USART.cs" />
     <Compile Include="Peripherals\DMA\Dma2DColorMode.cs" />
     <Compile Include="Peripherals\DMA\STM32DMA2D.cs" />
+    <Compile Include="Peripherals\DMA\ATCDMAC100.cs" />
     <Compile Include="Peripherals\Video\STM32LTDC.cs" />
     <Compile Include="Peripherals\Wireless\CC2538\InterruptRegister.cs" />
     <Compile Include="Peripherals\Wireless\CC2538\InterruptSource.cs" />

--- a/src/Emulator/Peripherals/Peripherals.csproj
+++ b/src/Emulator/Peripherals/Peripherals.csproj
@@ -228,6 +228,7 @@
     <Compile Include="Peripherals\GPIOPort\STM32F4GPIOPort_old.cs" />
     <Compile Include="Peripherals\GPIOPort\STM32_GPIOPort.cs" />
     <Compile Include="Peripherals\GPIOPort\STM32F1GPIOPort.cs" />
+    <Compile Include="Peripherals\GPIOPort\Virgo_pad.cs" />
     <Compile Include="Peripherals\GPIOPort\NXPGPIOPort.cs" />
     <Compile Include="Peripherals\GPIOPort\XilinxGPIOPS.cs" />
     <Compile Include="Peripherals\USBDeprecated\USBTablet.cs" />

--- a/src/Emulator/Peripherals/Peripherals/DMA/ATCDMAC100.cs
+++ b/src/Emulator/Peripherals/Peripherals/DMA/ATCDMAC100.cs
@@ -1,0 +1,630 @@
+//
+// Copyright (c) 2010-2023 Antmicro
+//
+//  This file is licensed under the MIT License.
+//  Full license text is available in 'licenses/MIT.txt'.
+//
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Antmicro.Renode.Core;
+using Antmicro.Renode.Core.Structure.Registers;
+using Antmicro.Renode.Exceptions;
+using Antmicro.Renode.Logging;
+using Antmicro.Renode.Peripherals.Bus;
+using Antmicro.Renode.Peripherals.Timers;
+using Antmicro.Renode.Time;
+using Antmicro.Renode.Utilities.Packets;
+
+namespace Antmicro.Renode.Peripherals.DMA
+{
+    public class ATCDMAC100 : BasicDoubleWordPeripheral, IKnownSize
+    {
+        public ATCDMAC100(IMachine machine) : base(machine)
+        {
+            engine = new DmaEngine(sysbus);
+            IRQ = new GPIO();
+            channels = new Channel[NumberOfChannels];
+            for (var i = 0; i < NumberOfChannels; ++i)
+            {
+                channels[i] = new Channel(this, i);
+            }
+            BuildRegisters();
+        }
+
+        public override void Reset()
+        {
+            signals.Clear();
+            foreach (var channel in channels)
+            {
+                channel.Reset();
+            }
+            base.Reset();
+            UpdateInterrupts();
+        }
+
+
+        public GPIO IRQ { get; }
+
+        public long Size => 0x400;
+
+        private void BuildRegisters()
+        {
+            Registers.Configuration.Define(this)
+                .WithValueField(0, 4, FieldMode.Read, name: "CHANNELNUM",
+                 valueProviderCallback: _ => NumberOfChannels)
+                .WithTag("FIFODEPTH", 4, 5)
+                .WithTag("REQUESTNUM", 10, 5)
+                .WithReservedBits(16, 14)
+                .WithTaggedFlag("REQUESTSYNC", 30)
+                .WithTaggedFlag("CHAINXFR", 31)
+            ;
+            Registers.Control.Define(this)
+                .WithFlag(0, FieldMode.Read | FieldMode.Write,
+                 writeCallback: (_, value) =>
+                 {
+                     //make it more simple
+                     if (value)
+                         Reset();
+                 },
+                name: "RESET")
+                .WithReservedBits(1, 31)
+            ;
+            Registers.InterruptStatus.Define(this)
+                .WithTag("ERROR", 0, 8)
+                .WithTag("ABORT", 8, 8)
+                .WithFlags(16, 8, FieldMode.WriteOneToClear | FieldMode.Read, writeCallback: (i, _, value) => channels[i].interruptTCstatus &= !value, valueProviderCallback: (i, _) => channels[i].interruptTCstatus, name: "TC")
+               // .WithFlags(16, 8,out channel.interruptTCstatus, FieldMode.WriteOneToClear | FieldMode.Read, writeCallback: (i, _, value) => {UpdateInterrupts();}, valueProviderCallback: (i, _) => channels[i].interruptTCstatus, name: "TC")
+                .WithReservedBits(24, 8)
+                .WithWriteCallback((_, __) => UpdateInterrupts())
+            ;
+
+           
+            Registers.ChannelEnable.Define(this)
+                .WithFlags(0, 8, valueProviderCallback: (i, _) => channels[i].ChEN, name: "CHEN")
+                .WithReservedBits(8, 24)
+            ;
+            Registers.ChannelAbort.Define(this)
+                .WithTag("CHABORT", 0, 8)
+                .WithReservedBits(8, 24)
+            ;
+             var channelDelta = (uint)((long)Registers.Channel1Control - (long)Registers.Channel0Control);
+            Registers.Channel0Control.BindMany(this, NumberOfChannels, i => channels[i].ControlRegister,channelDelta);
+            Registers.Channel0SourceAddress.BindMany(this, NumberOfChannels, i => channels[i].SourceAddressRegister,channelDelta);
+            Registers.Channel0DestinationAddress.BindMany(this, NumberOfChannels, i => channels[i].DestinationAddressRegister,channelDelta);
+            Registers.Channel0TransferSize.BindMany(this, NumberOfChannels, i => channels[i].TransferSizeRegister,channelDelta);
+            Registers.Channel0LinkListPointer.BindMany(this, NumberOfChannels, i => channels[i].LinkListPointerRegister,channelDelta);
+        }
+
+       /* private void UpdateInterrupts()
+        {
+            this.Log(LogLevel.Info, "Interrupt set for channels: {0}", String.Join(", ",
+                channels
+                    .Where(channel => channel.IRQ)
+                    .Select(channel => channel.Index)
+                ));
+            IRQ.Set(channels.Any(channel => channel.IRQ));
+            
+        }*/
+        private void UpdateInterrupts()
+        {      var state = false;
+        var ChannelCount=8;
+             for(var i = 0; i < ChannelCount; ++i)
+            {
+                state |= (!channels[i].interruptTCMask) && channels[i].interruptTCstatus;
+              //  this.InfoLog(" channels [i].interruptTCMask{0}", channels[i].interruptTCMask);
+              //  this.InfoLog(" channels [i].interruptTCstatus{0}", channels[i].interruptTCstatus);
+        }
+        
+        this.InfoLog("{0} interrupt", state ? "Setting" : "Unsetting");
+            IRQ.Set(state);
+        }
+        private readonly DmaEngine engine;
+        private readonly HashSet<int> signals;
+        private readonly Channel[] channels;
+
+        private const int NumberOfChannels = 8;
+        private enum Registers
+        {
+            Configuration = 0x10,
+            Control = 0x20,
+            InterruptStatus = 0x30,
+            ChannelEnable = 0x34,
+            ChannelAbort = 0x40,
+            Channel0Control = 0x44,
+            Channel0SourceAddress = 0x48,
+            Channel0DestinationAddress = 0x4C,
+            Channel0TransferSize = 0x50,
+            Channel0LinkListPointer = 0x54,
+            Channel1Control = 0x44 + 0x14,   //0x58
+            Channel1SourceAddress = 0x48 + 0x14, //0x5C
+            Channel1DestinationAddress = 0x4C + 0x14, //0X60
+            Channel1TransferSize = 0x50 + 0x14,  //0x64
+            Channel1LinkListPointer = 0x54 + 0x14, //0x68
+            Channel2Control = 0x44 + 2 * 0x14, //0x6C
+            Channel2SourceAddress = 0x48 + 2 * 0x14,//0x70
+            Channel2DestinationAddress = 0x4C + 2 * 0x14,//0x74
+            Channel2TransferSize = 0x50 + 2 * 0x14, //0x78
+            Channel2LinkListPointer = 0x54 + 2 * 0x14, //0x7C
+            Channel3Control = 0x44 + 3 * 0x14,
+            Channel3SourceAddress = 0x48 + 3 * 0x14,
+            Channel3DestinationAddress = 0x4C + 3 * 0x14,
+            Channel3TransferSize = 0x50 + 3 * 0x14,
+            Channel3LinkListPointer = 0x54 + 3 * 0x14,
+            Channel4Control = 0x44 + 4 * 0x14,
+            Channel4SourceAddress = 0x48 + 4 * 0x14,
+            Channel4DestinationAddress = 0x4C + 4 * 0x14,
+            Channel4TransferSize = 0x50 + 4 * 0x14,
+            Channel4LinkListPointer = 0x54 + 4 * 0x14,
+            Channel5Control = 0x44 + 5 * 0x14,
+            Channel5SourceAddress = 0x48 + 5 * 0x14,
+            Channel5DestinationAddress = 0x4C + 5 * 0x14,
+            Channel5TransferSize = 0x50 + 5 * 0x14,
+            Channel5LinkListPointer = 0x54 + 5 * 0x14,
+            Channel6Control = 0x44 + 6 * 0x14,
+            Channel6SourceAddress = 0x48 + 6 * 0x14,
+            Channel6DestinationAddress = 0x4C + 6 * 0x14,
+            Channel6TransferSize = 0x54 + 6 * 0x14,
+            Channel6LinkListPointer = 0x58 + 6 * 0x14,
+            Channel7Control = 0x44 + 7 * 0x14,
+            Channel7SourceAddress = 0x48 + 7 * 0x14,
+            Channel7DestinationAddress = 0x4C + 7 * 0x14,
+            Channel7TransferSize = 0x50 + 7 * 0x14,
+            Channel7LinkListPointer = 0x54 + 7 * 0x14,
+
+        }
+
+        private class Channel
+        {
+            public Channel(ATCDMAC100 parent, int index)
+            {
+                this.parent = parent;
+                Index = index;
+                descriptor = default(Descriptor);
+
+                ControlRegister = new DoubleWordRegister(parent)
+                    .WithFlag(0, FieldMode.Read | FieldMode.Write,
+                    writeCallback: (_, value) => descriptor.Enabled = value,
+                    name: "ENABLE")
+
+                   
+                    .WithFlag(1, out InterruptTCMask, FieldMode.Read | FieldMode.Write,
+                        writeCallback: (_, value) =>
+                        {
+                            descriptor.interruptTCMask = value;
+                            /*if (!value)
+                           {  parent.InfoLog("interrupt mask enable");
+                            parent.UpdateInterrupts();}
+                            else{
+                              parent.InfoLog("interrupt mask disable");
+                            parent.UpdateInterrupts();  
+                            }*/
+
+                        },valueProviderCallback: _ => descriptor.interruptTCMask ,
+                        name: "INTTCMASK")
+                    //Not implemented
+                    .WithFlag(2, FieldMode.Read | FieldMode.Write,
+                    writeCallback: (_, value) => descriptor.InterruptErrMask = value,
+                    name: "INTERRMASK")
+                    //Not implemented
+                    .WithFlag(3, FieldMode.Read | FieldMode.Write,
+                    writeCallback: (_, value) => descriptor.InterruptAbtMask = value,
+                    name: "INTABTMASK")
+
+                    .WithValueField(4, 4,
+                    writeCallback: (_, value) => descriptor.DstReqSel = (uint)value,
+                    name: "DSTREQSEL")
+
+                    .WithValueField(8, 4,
+                    writeCallback: (_, value) => descriptor.SrcReqSel =(uint) value,
+                    name: "SRCREQSEL")
+                    // In erf , destination address increment size
+                    //in atcdmac, destination address control
+                    //TOD0: Not implemented 
+                    .WithEnumField<DoubleWordRegister, AddressMode>(12, 2,
+                        writeCallback: (_, value) =>
+                        {
+                            descriptor.DstAddrCtrl = value;
+                            parent.InfoLog("Destination address control");
+                        },
+                        name: "DSTADDCTRL")
+
+                    //In erf , equal to source address increment size
+                    //in atcdma , source address control
+                    //TOD0: Not implemented 
+                    .WithEnumField<DoubleWordRegister, AddressMode>(14, 2,
+                        writeCallback: (_, value) =>
+                        {
+                            descriptor.SrcAddrCtrl = value;
+                            parent.InfoLog("Source address control");
+                        },
+                        name: "SRCADDCTRL")
+
+                    .WithFlag(16, FieldMode.Write | FieldMode.Read,
+                        writeCallback: (_, value) => descriptor.DstMode = value,
+                        name: "DSTMODE")
+
+                    .WithFlag(17, FieldMode.Write | FieldMode.Read,
+                        writeCallback: (_, value) => descriptor.SrcMode = value,
+                        name: "SRCMODE")
+                  
+                    .WithEnumField<DoubleWordRegister, SizeMode>(18, 2,
+                        writeCallback: (_, value) => 
+                        {descriptor.dstwidth = value;
+                        parent.InfoLog("destination width {0}",descriptor.dstwidth);
+                        
+                        },
+                        valueProviderCallback: _ => descriptor.dstwidth,
+                        name: "DSTWIDTH")
+
+                    .WithEnumField<DoubleWordRegister, SizeMode>(20, 2,
+                        writeCallback: (_, value) => 
+                        {
+                            descriptor.srcwidth = value;
+                            parent.InfoLog("source width {0} ",descriptor.srcwidth);
+                             },
+                        valueProviderCallback: _ => descriptor.srcwidth,
+                        name: "SRCWIDTH")
+                    //in atcdmac : This field indicates the number of transfers before DMA channel re-arbitration
+                    // in erf :  This bit-field controls the number of unit data transfers per arbitration cycle
+                    .WithEnumField<DoubleWordRegister, BlockSizeMode>(22, 3,
+                        writeCallback: (_, value) => {descriptor.blockSize = value;
+                        parent.InfoLog("source burst size {0} ",descriptor.blockSize);
+                       if (descriptor.Enabled)
+                        Transfer(); 
+                        // LinkLoad();
+                        else 
+                       parent.InfoLog("channel disable");
+                         },
+                        valueProviderCallback: _ => descriptor.blockSize,
+                        name: "SRCBURSTSIZE")
+                    .WithReservedBits(25, 4)
+
+                    .WithFlag(29, FieldMode.Read | FieldMode.Write,
+                        writeCallback: (_, value) =>
+                        {  
+                           descriptor.priority=value;
+                            if (value)
+                                parent.InfoLog(" priority enable");
+                            else
+                                parent.InfoLog(" priority disable");
+                        },
+                        name: "PRIORITY")
+
+                    .WithFlag(30, FieldMode.Read | FieldMode.Write,
+                        writeCallback: (_, value) =>
+                        {  
+                           descriptor.SRCREQSELB5=value;
+                            
+                        },
+                        name: "SRCREQSELB5")
+
+                    .WithFlag(31, FieldMode.Read | FieldMode.Write,
+                        writeCallback: (_, value) =>
+                        {  
+                           descriptor.DSTREQSELB5=value;
+                            
+                        },
+                        name: "DSTREQSELB5")
+            /*.WithWriteCallback((_, __) => {
+                                              
+                                                                           
+              })*/
+                ;
+                SourceAddressRegister = new DoubleWordRegister(parent)
+                    .WithValueField(0, 32,
+                        writeCallback: (_, value) => {descriptor.sourceAddress = (uint)value;
+                        parent.InfoLog("Execute Source Address register");} ,
+                        valueProviderCallback: _ => descriptor.sourceAddress,
+                        name: "SRCADDR")
+                ;
+                DestinationAddressRegister = new DoubleWordRegister(parent)
+                    .WithValueField(0, 32,
+                        writeCallback: (_, value) => {descriptor.destinationAddress = (uint)value;
+                        parent.InfoLog("Execute Destination Address register");},
+                        valueProviderCallback: _ => descriptor.destinationAddress,
+                        name: "DSTADDR")
+                ;
+                TransferSizeRegister = new DoubleWordRegister(parent)
+                    .WithValueField(0, 22,
+                        writeCallback: (_, value) =>
+                        {   
+                            descriptor.TranSize = (uint)value;
+                            parent.InfoLog("Transfer size {0} " ,descriptor.TranSize );
+                        },
+
+                        name: "TRANSIZE")
+                    .WithReservedBits(22, 9)
+                ;
+                LinkListPointerRegister = new DoubleWordRegister(parent)
+                    .WithReservedBits(0, 2)
+                    .WithValueField(2, 30,
+                        writeCallback: (_, value) =>{ descriptor.linkAddress = (uint)value;
+                        parent.InfoLog("Execute Link Address register");},
+                        valueProviderCallback: _ => descriptor.linkAddress,
+                        name: "LLPOINTER")
+                ;
+            }
+            public void Reset()
+            {
+                descriptor = default(Descriptor);
+                //interruptTCMask = false;
+                descriptorAddress = null;
+                requestDisable = false;
+                enabled = false;
+                done = false;
+            }
+
+            public int Index { get; }
+            public bool interruptTCstatus { get; set; }
+            public bool interruptTCMask => descriptor.interruptTCMask;
+
+            public bool IRQ => (!interruptTCMask) & interruptTCstatus ;
+            
+            public DoubleWordRegister ConfigurationRegister { get; }
+            public DoubleWordRegister ControlRegister { get; }
+            public DoubleWordRegister SourceAddressRegister { get; }
+            public DoubleWordRegister DestinationAddressRegister { get; }
+            public DoubleWordRegister TransferSizeRegister { get; }
+            public DoubleWordRegister LinkListPointerRegister { get; }
+
+            public bool ChEN =>descriptor.Enabled;
+
+            
+              public void LinkLoad()
+            {   parent.InfoLog("Link Loaded");
+                //LoadDescriptor();
+                StartTransferInner();
+                
+            
+            }
+            
+             private void StartTransferInner()
+             {
+                 if(isInProgress)
+                 {
+                     return;
+                 }
+
+                 isInProgress = true;
+                 var loaded = false;
+                 do
+                 {
+                     loaded = false;
+                     Transfer();
+                     if(LinkStructureAddress!=0)
+                     {
+                         loaded = true;
+                         LoadDescriptor();
+                        parent.InfoLog("Load next descriptor");
+                     }
+                 }
+                 while(loaded);
+                 isInProgress = false;
+             }
+      
+             private void LoadDescriptor()
+             {   
+                 var address = LinkStructureAddress;
+                  parent.InfoLog("LinkStructureAddress {0}", address); 
+                var data = parent.sysbus.ReadBytes(address, DescriptorSize);
+                 parent.InfoLog("var data {0}", data);
+                 descriptorAddress = address;
+                 descriptor = Packet.Decode<Descriptor>(data);
+                parent.InfoLog("Load descriptor");
+ //#if DEBUG
+                 parent.Log(LogLevel.Info, "Channel #{0} data {1}", Index, BitConverter.ToString(data));
+                 parent.Log(LogLevel.Info, "Channel #{0} Loaded {1}", Index, descriptor.PrettyString);
+// #endif
+             }
+
+            private void Transfer()
+            {
+               
+                var request = new Request(
+                    source: new Place(descriptor.sourceAddress),
+                    destination: new Place(descriptor.destinationAddress),
+                    size: Bytes,
+                    readTransferType: SizeAsTransferType,
+                    writeTransferType: SizeAsTransferType,
+                    sourceIncrementStep: SourceIncrement,
+                    destinationIncrementStep: DestinationIncrement
+                );
+               
+                parent.Log(LogLevel.Info, "Channel #{0} Performing Transfer", Index);
+                parent.engine.IssueCopy(request);
+            var blockSizeMultiplier = Math.Min(TranSize, BlockSizeMultiplier);
+            parent.InfoLog("Multiplier {0}",blockSizeMultiplier);
+            if(blockSizeMultiplier == TranSize)
+                            {   
+                                
+                                descriptor.TranSize = 0;
+                                parent.InfoLog("Blocksize multiplier equal to Transfer size {0}",descriptor.TranSize);
+                                interruptTCstatus=true;
+                            }
+                            else
+                            {
+                                descriptor.TranSize -= blockSizeMultiplier;
+                                parent.InfoLog("Transfer size decremented by {0}",descriptor.TranSize) ;
+                            }
+               
+                
+                descriptor.sourceAddress += SourceIncrement * blockSizeMultiplier;
+                descriptor.destinationAddress += DestinationIncrement * blockSizeMultiplier;
+                parent.UpdateInterrupts();
+                
+            }
+
+            private uint BlockSizeMultiplier
+            {
+                get
+                {
+                    switch (descriptor.blockSize)
+                    {
+                        
+                        case BlockSizeMode.Unit1:
+                        parent.Log(LogLevel.Info, "1 transfer");
+                        return 1u << (byte)descriptor.blockSize;
+
+                        case BlockSizeMode.Unit2:
+                        parent.Log(LogLevel.Info, "2 transfers");
+                        return 1u << (byte)descriptor.blockSize;
+
+                        case BlockSizeMode.Unit4:
+                        parent.Log(LogLevel.Info, "4 transfers");
+                        return 1u << (byte)descriptor.blockSize;
+
+                        case BlockSizeMode.Unit8:
+                        parent.Log(LogLevel.Info, "8 transfers");
+                        return 1u << (byte)descriptor.blockSize;
+
+                        case BlockSizeMode.Unit16:
+                        parent.Log(LogLevel.Info, "16 transfers");
+                        return 1u << (byte)descriptor.blockSize;
+
+                        case BlockSizeMode.Unit32:
+                        parent.Log(LogLevel.Info, "32 transfers");
+                        return 1u << (byte)descriptor.blockSize;
+
+                        case BlockSizeMode.Unit64:
+                        parent.Log(LogLevel.Info, "64 transfers");
+                        return 1u << (byte)descriptor.blockSize;
+
+                        case BlockSizeMode.Unit128:
+                        parent.Log(LogLevel.Info, "128 transfers");
+                        return 1u << (byte)descriptor.blockSize;
+
+                        default:
+                            parent.Log(LogLevel.Warning, "Channel #{0} Invalid Block Size Mode value.", Index);
+                            return 0;
+                    }
+                }
+            }
+            //TODO:Review fields w.r.t transfer function
+            private uint TranSize => (uint)descriptor.TranSize + 1;
+            private ulong LinkStructureAddress => (ulong)descriptor.linkAddress << 2;
+
+            private uint SourceIncrement => descriptor.SrcAddrCtrl == AddressMode.Fixed ? 0u : ((1u << (byte)descriptor.srcwidth) << (byte)descriptor.SrcAddrCtrl);
+            private uint DestinationIncrement => descriptor.DstAddrCtrl == AddressMode.Fixed ? 0u : ((1u << (byte)descriptor.dstwidth) << (byte)descriptor.DstAddrCtrl);
+            private TransferType SizeAsTransferType => (TransferType)(1 << (byte)descriptor.srcwidth);
+            private int Bytes =>(int) Math.Min(TranSize,BlockSizeMultiplier) << (byte)descriptor.srcwidth; //(int)
+            
+        
+            private Descriptor descriptor;
+            private ulong? descriptorAddress;
+            private bool requestDisable;
+            private bool enabled;
+            private bool done;
+
+            // Accesses to sysubs may cause changes in signals, but we should ignore those during active transaction
+            private bool isInProgress;
+            private IFlagRegisterField InterruptTCMask;
+            private readonly ATCDMAC100 parent;
+
+            protected readonly int DescriptorSize = Packet.CalculateLength<Descriptor>();
+             
+           protected enum BlockSizeMode 
+            {
+                Unit1 = 0x0,
+                Unit2 = 0x1,
+                Unit4 = 0x2,
+                Unit8 = 0x3,
+                Unit16 = 0x4,
+                Unit32 = 0x5,
+                Unit64 = 0x6,
+                Unit128 = 0x7,
+
+            }
+            protected enum AddressMode 
+            {
+                Increment = 0x0,
+                Decrement = 0x1,
+                Fixed = 0x2,
+                Reserved = 0x3,
+            }
+
+            protected enum SizeMode 
+            {
+                Byte = 0x0,
+                HalfWord = 0x1,
+                Word = 0x2,
+
+            }
+
+            [LeastSignificantByteFirst]
+            private struct Descriptor
+            {
+                public string PrettyString => $@"Descriptor {{
+            
+    Enable: {Enabled},
+    InterruptTCMask: {interruptTCMask},
+    InterruptErrMask: {InterruptErrMask},
+    InterruptAbtMask: {InterruptAbtMask},
+    DstReqSel: {DstReqSel},
+    SrcReqSel: {SrcReqSel},
+    DstAddrCtrl: {DstAddrCtrl},
+    SrcAddrCtrl: {SrcAddrCtrl},
+    DstMode: {DstMode},
+    SrcMode: {SrcMode},
+    dstwidth: {dstwidth},
+    srcwidth: {srcwidth},
+    priority:{priority},
+    SRCREQSELB5:{SRCREQSELB5},
+    DSTREQSELB5:{DSTREQSELB5}
+    SrcBurstSize:{blockSize},
+    sourceAddress: 0x{sourceAddress:X},
+    destinationAddress: 0x{destinationAddress:X},
+    TranSize: {TranSize},
+    linkAddress: 0x{(linkAddress << 2):X}
+}}";
+
+                // Some of this fields are read only via sysbus, but can be loaded from memory
+                // bits : starting position w.r.t register
+#pragma warning disable 649
+                [PacketField, Offset(doubleWords: 0, bits: 0), Width(1)]
+                public bool Enabled;
+                [PacketField, Offset(doubleWords: 0, bits: 1), Width(1)]
+                public bool interruptTCMask;
+                [PacketField, Offset(doubleWords: 0, bits: 2), Width(1)]
+                public bool InterruptErrMask;
+                [PacketField, Offset(doubleWords: 0, bits: 3), Width(1)]
+                public bool InterruptAbtMask;
+                [PacketField, Offset(doubleWords: 0, bits: 4), Width(4)]
+                public uint DstReqSel;
+                [PacketField, Offset(doubleWords: 0, bits: 8), Width(4)]
+                public uint SrcReqSel;
+                [PacketField, Offset(doubleWords: 0, bits: 12), Width(2)]
+                public AddressMode DstAddrCtrl;  
+                [PacketField, Offset(doubleWords: 0, bits: 14), Width(2)]
+                public AddressMode SrcAddrCtrl; 
+                [PacketField, Offset(doubleWords: 0, bits: 16), Width(1)]
+                public bool DstMode; 
+                [PacketField, Offset(doubleWords: 0, bits: 17), Width(1)]
+                public bool SrcMode;  
+                [PacketField, Offset(doubleWords: 0, bits: 18), Width(2)]
+                public SizeMode dstwidth;  
+                [PacketField, Offset(doubleWords: 0, bits: 20), Width(2)]
+                public SizeMode srcwidth;  
+                [PacketField, Offset(doubleWords: 0, bits: 22), Width(3)]
+                public BlockSizeMode blockSize; 
+                [PacketField, Offset(doubleWords: 0, bits: 29), Width(1)]
+                public bool priority; 
+                [PacketField, Offset(doubleWords: 0, bits: 30), Width(1)]
+                public bool SRCREQSELB5; 
+                [PacketField, Offset(doubleWords: 0, bits: 31), Width(1)]
+                public bool DSTREQSELB5; 
+                [PacketField, Offset(doubleWords: 1, bits: 0), Width(32)]
+                public uint sourceAddress;        
+                [PacketField, Offset(doubleWords: 2, bits: 0), Width(32)]
+                public uint destinationAddress;   
+                [PacketField, Offset(doubleWords: 3, bits: 0), Width(22)]
+                public uint TranSize;    
+                [PacketField, Offset(doubleWords: 4, bits: 2), Width(30)]
+                public uint linkAddress;
+#pragma warning restore 649
+            }
+        }
+    }
+}

--- a/src/Emulator/Peripherals/Peripherals/DMA/ATCDMAC100.cs
+++ b/src/Emulator/Peripherals/Peripherals/DMA/ATCDMAC100.cs
@@ -264,7 +264,7 @@ namespace Antmicro.Renode.Peripherals.DMA
                     .WithValueField(0, 22,
                         writeCallback: (_, value) =>
                         {                 
-                           descriptor.TranSize = (uint)value
+                           descriptor.TranSize = (uint)value;
                            parent.InfoLog("Transfer size {0} ", descriptor.TranSize);
                         },
                         name: "TRANSIZE")

--- a/src/Emulator/Peripherals/Peripherals/DMA/ATCDMAC100.cs
+++ b/src/Emulator/Peripherals/Peripherals/DMA/ATCDMAC100.cs
@@ -504,7 +504,7 @@ namespace Antmicro.Renode.Peripherals.DMA
                 }
 
             } 
-           // private bool SourceDec =>  if (descriptor.SrcAddrCtrl==AddressMode.Decrement)  {SourceDec=false;}
+
                 
            public bool SourceInc;
            public bool SourceDec;
@@ -514,7 +514,7 @@ namespace Antmicro.Renode.Peripherals.DMA
             
 
 
-            private bool DestinationMode => descriptor.DstAddrCtrl;
+           
 
             private Descriptor descriptor;
             private ulong? descriptorAddress;

--- a/src/Emulator/Peripherals/Peripherals/DMA/ATCDMAC100.cs
+++ b/src/Emulator/Peripherals/Peripherals/DMA/ATCDMAC100.cs
@@ -1,0 +1,652 @@
+//
+// Copyright (c) 2010-2023 Antmicro
+//
+//  This file is licensed under the MIT License.
+//  Full license text is available in 'licenses/MIT.txt'.
+//
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Antmicro.Renode.Core;
+using Antmicro.Renode.Core.Structure.Registers;
+using Antmicro.Renode.Exceptions;
+using Antmicro.Renode.Logging;
+using Antmicro.Renode.Peripherals.Bus;
+using Antmicro.Renode.Peripherals.Timers;
+using Antmicro.Renode.Time;
+using Antmicro.Renode.Utilities.Packets;
+
+namespace Antmicro.Renode.Peripherals.DMA
+{
+    public class ATCDMAC100 : BasicDoubleWordPeripheral, IKnownSize
+    {
+        public ATCDMAC100(IMachine machine) : base(machine)
+        {
+            engine = new DmaEngine(sysbus);
+            // signals = new HashSet<int>();
+            IRQ = new GPIO();
+            channels = new Channel[NumberOfChannels];
+            for (var i = 0; i < NumberOfChannels; ++i)
+            {
+                channels[i] = new Channel(this, i);
+            }
+            BuildRegisters();
+        }
+
+        public override void Reset()
+        {
+            signals.Clear();
+            foreach (var channel in channels)
+            {
+                channel.Reset();
+            }
+            base.Reset();
+            UpdateInterrupts();
+        }
+
+
+        public GPIO IRQ { get; }
+
+        public long Size => 0x400;
+
+        private void BuildRegisters()
+        {
+            Registers.Configuration.Define(this)
+                .WithValueField(0, 4, FieldMode.Read, name: "CHANNELNUM",
+                 valueProviderCallback: _ => NumberOfChannels)
+                .WithTag("FIFODEPTH", 4, 5)
+                .WithTag("REQUESTNUM", 10, 5)
+                .WithReservedBits(16, 14)
+                .WithTaggedFlag("REQUESTSYNC", 30)
+                .WithTaggedFlag("CHAINXFR", 31)
+            ;
+            Registers.Control.Define(this)
+                .WithFlag(0, FieldMode.Read | FieldMode.Write,
+                 writeCallback: (_, value) =>
+                 {
+                     //make it more simple
+                     if (value)
+                         Reset();
+                 },
+                name: "RESET")
+                .WithReservedBits(1, 31)
+            ;
+            Registers.InterruptStatus.Define(this)
+                .WithTag("ERROR", 0, 8)
+                .WithTag("ABORT", 8, 8)
+                .WithFlags(16, 8, FieldMode.WriteOneToClear | FieldMode.Read, writeCallback: (i, _, value) => channels[i].TC &= !value, valueProviderCallback: (i, _) => channels[i].TC, name: "TC")
+                .WithReservedBits(24, 8)
+                .WithWriteCallback((_, __) => UpdateInterrupts())
+            ;
+
+            //remains same for atcdmac
+            Registers.ChannelEnable.Define(this)
+                .WithFlags(0, 8, valueProviderCallback: (i, _) => channels[i].ChEN, name: "CHEN")
+                .WithReservedBits(8, 24)
+            ;
+            Registers.ChannelAbort.Define(this)
+                .WithTag("CHABORT", 0, 8)
+                .WithReservedBits(8, 24)
+            ;
+             var channelDelta = (uint)((long)Registers.Channel1Control - (long)Registers.Channel0Control);
+            Registers.Channel0Control.BindMany(this, NumberOfChannels, i => channels[i].ControlRegister,channelDelta);
+            //channel n source address register atcdmac
+            //Channel Descriptor Source Data Address Register for efr
+            Registers.Channel0SourceAddress.BindMany(this, NumberOfChannels, i => channels[i].SourceAddressRegister,channelDelta);
+            //Channel destination address register atcdmac
+            //Channel Descriptor Destination Data Address Register for efr
+            Registers.Channel0DestinationAddress.BindMany(this, NumberOfChannels, i => channels[i].DestinationAddressRegister,channelDelta);
+            Registers.Channel0TransferSize.BindMany(this, NumberOfChannels, i => channels[i].TransferSizeRegister,channelDelta);
+            Registers.Channel0LinkListPointer.BindMany(this, NumberOfChannels, i => channels[i].LinkListPointerRegister,channelDelta);
+        }
+
+       /* private void UpdateInterrupts()
+        {
+            this.Log(LogLevel.Info, "Interrupt set for channels: {0}", String.Join(", ",
+                channels
+                    .Where(channel => channel.IRQ)
+                    .Select(channel => channel.Index)
+                ));
+            IRQ.Set(channels.Any(channel => channel.IRQ));
+            
+        }*/
+         private void UpdateInterrupts()
+        {      var state = false;
+        var ChannelCount=8;
+             for(var i = 0; i < ChannelCount; ++i)
+            {
+                state |= channels[i].interruptTCMask && channels[i].TC;
+           
+            
+        }
+        this.InfoLog("{0} interrupt", state ? "Setting" : "Unsetting");
+            IRQ.Set(state);
+        }
+        private readonly DmaEngine engine;
+        private readonly HashSet<int> signals;
+        private readonly Channel[] channels;
+
+        private const int NumberOfChannels = 8;
+        private enum Registers
+        {
+            Configuration = 0x10,
+            Control = 0x20,
+            InterruptStatus = 0x30,
+            ChannelEnable = 0x34,
+            ChannelAbort = 0x40,
+            Channel0Control = 0x44,
+            Channel0SourceAddress = 0x48,
+            Channel0DestinationAddress = 0x4C,
+            Channel0TransferSize = 0x50,
+            Channel0LinkListPointer = 0x54,
+            Channel1Control = 0x44 + 0x14,   //0x58
+            Channel1SourceAddress = 0x48 + 0x14, //0x5C
+            Channel1DestinationAddress = 0x4C + 0x14, //0X60
+            Channel1TransferSize = 0x50 + 0x14,  //0x64
+            Channel1LinkListPointer = 0x54 + 0x14, //0x68
+            Channel2Control = 0x44 + 2 * 0x14, //0x6C
+            Channel2SourceAddress = 0x48 + 2 * 0x14,//0x70
+            Channel2DestinationAddress = 0x4C + 2 * 0x14,//0x74
+            Channel2TransferSize = 0x50 + 2 * 0x14, //0x78
+            Channel2LinkListPointer = 0x54 + 2 * 0x14, //0x7C
+            Channel3Control = 0x44 + 3 * 0x14,
+            Channel3SourceAddress = 0x48 + 3 * 0x14,
+            Channel3DestinationAddress = 0x4C + 3 * 0x14,
+            Channel3TransferSize = 0x50 + 3 * 0x14,
+            Channel3LinkListPointer = 0x54 + 3 * 0x14,
+            Channel4Control = 0x44 + 4 * 0x14,
+            Channel4SourceAddress = 0x48 + 4 * 0x14,
+            Channel4DestinationAddress = 0x4C + 4 * 0x14,
+            Channel4TransferSize = 0x50 + 4 * 0x14,
+            Channel4LinkListPointer = 0x54 + 4 * 0x14,
+            Channel5Control = 0x44 + 5 * 0x14,
+            Channel5SourceAddress = 0x48 + 5 * 0x14,
+            Channel5DestinationAddress = 0x4C + 5 * 0x14,
+            Channel5TransferSize = 0x50 + 5 * 0x14,
+            Channel5LinkListPointer = 0x54 + 5 * 0x14,
+            Channel6Control = 0x44 + 6 * 0x14,
+            Channel6SourceAddress = 0x48 + 6 * 0x14,
+            Channel6DestinationAddress = 0x4C + 6 * 0x14,
+            Channel6TransferSize = 0x54 + 6 * 0x14,
+            Channel6LinkListPointer = 0x58 + 6 * 0x14,
+            Channel7Control = 0x44 + 7 * 0x14,
+            Channel7SourceAddress = 0x48 + 7 * 0x14,
+            Channel7DestinationAddress = 0x4C + 7 * 0x14,
+            Channel7TransferSize = 0x50 + 7 * 0x14,
+            Channel7LinkListPointer = 0x54 + 7 * 0x14,
+
+        }
+
+        private class Channel
+        {
+            public Channel(ATCDMAC100 parent, int index)
+            {
+                this.parent = parent;
+                Index = index;
+                descriptor = default(Descriptor);
+
+                ControlRegister = new DoubleWordRegister(parent)
+                    .WithFlag(0, FieldMode.Read | FieldMode.Write,
+                    writeCallback: (_, value) => descriptor.Enabled = value,
+                    name: "ENABLE")
+
+                    // in atcdmac , channel terminal count interrupt mask
+                    // in stm32 /stm32ldma, interrupt on complete TCIE
+                    .WithFlag(1, out InterruptTCMask, FieldMode.Read | FieldMode.Write,
+                        writeCallback: (_, value) =>
+                        {
+                            descriptor.interruptTCMask = value;
+                            parent.UpdateInterrupts();
+
+                        },valueProviderCallback: _ => descriptor.interruptTCMask ,
+                        name: "INTTCMASK")
+                    //Not implemented
+                    .WithFlag(2, FieldMode.Read | FieldMode.Write,
+                    writeCallback: (_, value) => descriptor.InterruptErrMask = value,
+                    name: "INTERRMASK")
+                    //Not implemented
+                    .WithFlag(3, FieldMode.Read | FieldMode.Write,
+                    writeCallback: (_, value) => descriptor.InterruptAbtMask = value,
+                    name: "INTABTMASK")
+
+                    .WithValueField(4, 4,
+                    writeCallback: (_, value) => descriptor.DstReqSel = (uint)value,
+                    name: "DSTREQSEL")
+
+                    .WithValueField(8, 4,
+                    writeCallback: (_, value) => descriptor.SrcReqSel =(uint) value,
+                    name: "SRCREQSEL")
+                    // In erf , destination address increment size
+                    //in atcdmac, destination address control
+                    //TOD0: Not implemented 
+                    .WithEnumField<DoubleWordRegister, AddressMode>(12, 2,
+                        writeCallback: (_, value) =>
+                        {
+                            descriptor.DstAddrCtrl = value;
+                            parent.InfoLog("Destination address control");
+                        },
+                        name: "DSTADDCTRL")
+
+                    //In erf , equal to source address increment size
+                    //in atcdma , source address control
+                    //TOD0: Not implemented 
+                    .WithEnumField<DoubleWordRegister, AddressMode>(14, 2,
+                        writeCallback: (_, value) =>
+                        {
+                            descriptor.SrcAddrCtrl = value;
+                            parent.InfoLog("Source address control");
+                        },
+                        name: "SRCADDCTRL")
+
+                    .WithFlag(16, FieldMode.Write | FieldMode.Read,
+                        writeCallback: (_, value) => descriptor.DstMode = value,
+                        name: "DSTMODE")
+
+                    .WithFlag(17, FieldMode.Write | FieldMode.Read,
+                        writeCallback: (_, value) => descriptor.SrcMode = value,
+                        name: "SRCMODE")
+                    //in erf indicates the data transfer size
+                    // in atcdmac , source transfer width, destination transfer width is required
+                    .WithEnumField<DoubleWordRegister, SizeMode>(18, 2,
+                        writeCallback: (_, value) => 
+                        {descriptor.dstwidth = value;
+                        parent.InfoLog("destination width {0}",descriptor.dstwidth);
+                        
+                        },
+                        valueProviderCallback: _ => descriptor.dstwidth,
+                        name: "DSTWIDTH")
+
+                    .WithEnumField<DoubleWordRegister, SizeMode>(20, 2,
+                        writeCallback: (_, value) => 
+                        {
+                            descriptor.srcwidth = value;
+                            parent.InfoLog("source width {0} ",descriptor.srcwidth);},
+                        valueProviderCallback: _ => descriptor.srcwidth,
+                        name: "SRCWIDTH")
+                    //in atcdmac : This field indicates the number of transfers before DMA channel re-arbitration
+                    // in erf :  This bit-field controls the number of unit data transfers per arbitration cycle
+                    .WithEnumField<DoubleWordRegister, BlockSizeMode>(22, 3,
+                        writeCallback: (_, value) => {descriptor.blockSize = value;
+                        parent.InfoLog("source burst size {0} ",descriptor.blockSize);
+                        },
+                        valueProviderCallback: _ => descriptor.blockSize,
+                        name: "SRCBURSTSIZE")
+                    .WithReservedBits(25, 4)
+
+                    .WithFlag(29, FieldMode.Read | FieldMode.Write,
+                        writeCallback: (_, value) =>
+                        {  
+                           descriptor.priority=value;
+                            if (value)
+                                parent.InfoLog(" priority enable");
+                            else
+                                parent.InfoLog(" priority disable");
+                        },
+                        name: "PRIORITY")
+
+                    .WithFlag(30, FieldMode.Read | FieldMode.Write,
+                        writeCallback: (_, value) =>
+                        {  
+                           descriptor.SRCREQSELB5=value;
+                            
+                        },
+                        name: "SRCREQSELB5")
+
+                    .WithFlag(31, FieldMode.Read | FieldMode.Write,
+                        writeCallback: (_, value) =>
+                        {  
+                           descriptor.DSTREQSELB5=value;
+                            
+                        },
+                        name: "DSTREQSELB5")
+            .WithChangeCallback((_, __) => { if(descriptor.Enabled) {
+                                               LinkLoad();
+                                               parent.InfoLog("Channel enable");
+                                                }
+                                            else 
+                                              { parent.InfoLog("Channel disable");
+                                                 }                               
+              })
+                ;
+                SourceAddressRegister = new DoubleWordRegister(parent)
+                    .WithValueField(0, 32,
+                        writeCallback: (_, value) => descriptor.sourceAddress = (uint)value,
+                        valueProviderCallback: _ => descriptor.sourceAddress,
+                        name: "SRCADDR")
+                ;
+                DestinationAddressRegister = new DoubleWordRegister(parent)
+                    .WithValueField(0, 32,
+                        writeCallback: (_, value) => descriptor.destinationAddress = (uint)value,
+                        valueProviderCallback: _ => descriptor.destinationAddress,
+                        name: "DSTADDR")
+                ;
+                TransferSizeRegister = new DoubleWordRegister(parent)
+                    .WithValueField(0, 22,
+                        writeCallback: (_, value) =>
+                        {
+                            descriptor.TranSize = (uint)value;
+                            parent.InfoLog("Transfer size {0} " ,descriptor.TranSize );
+                        },
+
+                        name: "TRANSIZE")
+                    .WithReservedBits(22, 9)
+                ;
+                LinkListPointerRegister = new DoubleWordRegister(parent)
+                    .WithReservedBits(0, 2)
+                    .WithValueField(2, 30,
+                        writeCallback: (_, value) => descriptor.linkAddress = (uint)value,
+                        valueProviderCallback: _ => descriptor.linkAddress,
+                        name: "LLPOINTER")
+                ;
+            }
+            public void Reset()
+            {
+                descriptor = default(Descriptor);
+                //interruptTCMask = false;
+                descriptorAddress = null;
+                requestDisable = false;
+                enabled = false;
+                done = false;
+            }
+
+            public int Index { get; }
+            public bool TC { get; set; }
+            public bool interruptTCMask => descriptor.interruptTCMask;
+
+            public bool IRQ => interruptTCMask & TC;
+            
+            public DoubleWordRegister ConfigurationRegister { get; }
+            public DoubleWordRegister ControlRegister { get; }
+            public DoubleWordRegister SourceAddressRegister { get; }
+            public DoubleWordRegister DestinationAddressRegister { get; }
+            public DoubleWordRegister TransferSizeRegister { get; }
+            public DoubleWordRegister LinkListPointerRegister { get; }
+
+            public bool ChEN =>descriptor.Enabled;
+
+            
+              public void LinkLoad()
+            {
+                LoadDescriptor();
+                StartTransferInner();
+                parent.InfoLog("Link Loaded");
+            
+            }
+            //TODO: review if and while condition
+             private void StartTransferInner()
+             {
+                 if(isInProgress)
+                 {
+                     return;
+                 }
+
+                 isInProgress = true;
+                 var loaded = false;
+                 do
+                 {
+                     loaded = false;
+                     Transfer();
+                     if(descriptor.linkAddress!=0)
+                     {
+                         loaded = true;
+                         LoadDescriptor();
+                        parent.InfoLog("Load next descriptor");
+                     }
+                 }
+                 while(loaded);
+                 isInProgress = false;
+             }
+             //TODO:Review Load descriptor  (if condition)
+             private void LoadDescriptor()
+             {
+                 var address = LinkStructureAddress;
+                 if(descriptorAddress.HasValue)
+                 {
+                     address += descriptorAddress.Value;
+                 }
+                 var data = parent.sysbus.ReadBytes(address, DescriptorSize);
+                 descriptorAddress = address;
+                 descriptor = Packet.Decode<Descriptor>(data);
+                parent.InfoLog("Load descriptor");
+ #if DEBUG
+                 parent.Log(LogLevel.Noisy, "Channel #{0} data {1}", Index, BitConverter.ToString(data));
+                 parent.Log(LogLevel.Debug, "Channel #{0} Loaded {1}", Index, descriptor.PrettyString);
+ #endif
+             }
+
+            private void Transfer()
+            {
+               
+                var request = new Request(
+                    source: new Place(descriptor.sourceAddress),
+                    destination: new Place(descriptor.destinationAddress),
+                    size: Bytes,
+                    readTransferType: SizeAsTransferType,
+                    writeTransferType: SizeAsTransferType,
+                    sourceIncrementStep: SourceIncrement,
+                    destinationIncrementStep: DestinationIncrement
+                );
+            var blockSizeMultiplier = Math.Min(TranSize, BlockSizeMultiplier);
+            parent.InfoLog("Multiplier {0}",blockSizeMultiplier);
+            if(blockSizeMultiplier == TranSize)
+                            {   
+                                
+                                descriptor.TranSize = 0;
+                                parent.InfoLog("Blocksize multiplier equal to Transfer size {0}",descriptor.TranSize);
+                            }
+                            else
+                            {
+                                descriptor.TranSize -= blockSizeMultiplier;
+                                parent.InfoLog("Transfer size decremented by {0}",descriptor.TranSize) ;
+                            }
+               // parent.Log(LogLevel.Debug, "Channel #{0} Performing Transfer", Index);
+                parent.Log(LogLevel.Info, "Channel #{0} Performing Transfer", Index);
+                parent.engine.IssueCopy(request);
+                
+                descriptor.sourceAddress += SourceIncrement * blockSizeMultiplier;
+                descriptor.destinationAddress += DestinationIncrement * blockSizeMultiplier;
+                parent.UpdateInterrupts();
+                
+            }
+
+            private uint BlockSizeMultiplier
+            {
+                get
+                {
+                    switch (descriptor.blockSize)
+                    {
+                        
+                        case BlockSizeMode.Unit1:
+                        parent.Log(LogLevel.Info, "1 transfer");
+                        return 1u << (byte)descriptor.blockSize;
+
+                        case BlockSizeMode.Unit2:
+                        parent.Log(LogLevel.Info, "2 transfers");
+                        return 1u << (byte)descriptor.blockSize;
+
+                        case BlockSizeMode.Unit4:
+                        parent.Log(LogLevel.Info, "4 transfers");
+                        return 1u << (byte)descriptor.blockSize;
+
+                        case BlockSizeMode.Unit8:
+                        parent.Log(LogLevel.Info, "8 transfers");
+                        return 1u << (byte)descriptor.blockSize;
+
+                        case BlockSizeMode.Unit16:
+                        parent.Log(LogLevel.Info, "16 transfers");
+                        return 1u << (byte)descriptor.blockSize;
+
+                        case BlockSizeMode.Unit32:
+                        parent.Log(LogLevel.Info, "32 transfers");
+                        return 1u << (byte)descriptor.blockSize;
+
+                        case BlockSizeMode.Unit64:
+                        parent.Log(LogLevel.Info, "64 transfers");
+                        return 1u << (byte)descriptor.blockSize;
+
+                        case BlockSizeMode.Unit128:
+                        parent.Log(LogLevel.Info, "128 transfers");
+                        return 1u << (byte)descriptor.blockSize;
+
+                        default:
+                            parent.Log(LogLevel.Warning, "Channel #{0} Invalid Block Size Mode value.", Index);
+                            return 0;
+                    }
+                }
+            }
+            //TODO:Review fields w.r.t transfer function
+            private uint TranSize => (uint)descriptor.TranSize + 1;
+            private ulong LinkStructureAddress => (ulong)descriptor.linkAddress << 2;
+
+            private uint SourceIncrement => descriptor.SrcAddrCtrl == AddressMode.Fixed ? 0u : ((1u << (byte)descriptor.srcwidth) << (byte)descriptor.SrcAddrCtrl);
+            private uint DestinationIncrement => descriptor.DstAddrCtrl == AddressMode.Fixed ? 0u : ((1u << (byte)descriptor.dstwidth) << (byte)descriptor.DstAddrCtrl);
+            private TransferType SizeAsTransferType => (TransferType)(1 << (byte)descriptor.srcwidth);
+            private int Bytes =>(int) Math.Min(TranSize,BlockSizeMultiplier) << (byte)descriptor.srcwidth; //(int)
+            
+        
+            private Descriptor descriptor;
+            private ulong? descriptorAddress;
+            private bool requestDisable;
+            private bool enabled;
+            private bool done;
+
+            // Accesses to sysubs may cause changes in signals, but we should ignore those during active transaction
+            private bool isInProgress;
+            private IFlagRegisterField InterruptTCMask;
+            private readonly ATCDMAC100 parent;
+
+            protected readonly int DescriptorSize = Packet.CalculateLength<Descriptor>();
+              /* protected enum BlockSizeMode : uint
+            {
+                Unit1 = 0,
+                Unit2 = 1,
+                Unit4 = 2,
+                Unit8 = 3,
+                Unit16 = 4,
+                Unit32 = 5,
+                Unit64 = 6,
+                Unit128 = 7,
+
+            }
+            protected enum AddressMode : uint
+            {
+                Increment = 0,
+                Decrement = 1,
+                Fixed = 2,
+                Reserved = 3,
+            }
+
+            protected enum SizeMode : uint
+            {
+                Byte = 0,
+                HalfWord = 1,
+                Word = 2,
+
+            }*/
+
+           protected enum BlockSizeMode 
+            {
+                Unit1 = 0x0,
+                Unit2 = 0x1,
+                Unit4 = 0x2,
+                Unit8 = 0x3,
+                Unit16 = 0x4,
+                Unit32 = 0x5,
+                Unit64 = 0x6,
+                Unit128 = 0x7,
+
+            }
+            protected enum AddressMode 
+            {
+                Increment = 0x0,
+                Decrement = 0x1,
+                Fixed = 0x2,
+                Reserved = 0x3,
+            }
+
+            protected enum SizeMode 
+            {
+                Byte = 0x0,
+                HalfWord = 0x1,
+                Word = 0x2,
+
+            }
+
+            [LeastSignificantByteFirst]
+            private struct Descriptor
+            {
+                public string PrettyString => $@"Descriptor {{
+            
+    Enable: {Enabled},
+    InterruptTCMask: {interruptTCMask},
+    InterruptErrMask: {InterruptErrMask},
+    InterruptAbtMask: {InterruptAbtMask},
+    DstReqSel: {DstReqSel},
+    SrcReqSel: {SrcReqSel},
+    DstAddrCtrl: {DstAddrCtrl},
+    SrcAddrCtrl: {SrcAddrCtrl},
+    DstMode: {DstMode},
+    SrcMode: {SrcMode},
+    dstwidth: {dstwidth},
+    srcwidth: {srcwidth},
+    priority:{priority},
+    SRCREQSELB5:{SRCREQSELB5},
+    DSTREQSELB5:{DSTREQSELB5}
+    SrcBurstSize:{blockSize},
+    sourceAddress: 0x{sourceAddress:X},
+    destinationAddress: 0x{destinationAddress:X},
+    TranSize: {TranSize},
+    linkAddress: 0x{(linkAddress << 2):X}
+}}";
+
+                // Some of this fields are read only via sysbus, but can be loaded from memory
+                //TODO : update packet fields
+                // bits : starting position w.r.t register
+#pragma warning disable 649
+                [PacketField, Offset(doubleWords: 0, bits: 0), Width(1)]
+                public bool Enabled;
+                [PacketField, Offset(doubleWords: 0, bits: 1), Width(1)]
+                public bool interruptTCMask;
+                [PacketField, Offset(doubleWords: 0, bits: 2), Width(1)]
+                public bool InterruptErrMask;
+                [PacketField, Offset(doubleWords: 0, bits: 3), Width(1)]
+                public bool InterruptAbtMask;
+                [PacketField, Offset(doubleWords: 0, bits: 4), Width(4)]
+                public uint DstReqSel;
+                [PacketField, Offset(doubleWords: 0, bits: 8), Width(4)]
+                public uint SrcReqSel;
+                [PacketField, Offset(doubleWords: 0, bits: 12), Width(2)]
+                public AddressMode DstAddrCtrl;  
+                [PacketField, Offset(doubleWords: 0, bits: 14), Width(2)]
+                public AddressMode SrcAddrCtrl; 
+                [PacketField, Offset(doubleWords: 0, bits: 16), Width(1)]
+                public bool DstMode; 
+                [PacketField, Offset(doubleWords: 0, bits: 17), Width(1)]
+                public bool SrcMode;  
+                [PacketField, Offset(doubleWords: 0, bits: 18), Width(2)]
+                public SizeMode dstwidth;  
+                [PacketField, Offset(doubleWords: 0, bits: 20), Width(2)]
+                public SizeMode srcwidth;  
+                [PacketField, Offset(doubleWords: 0, bits: 22), Width(3)]
+                public BlockSizeMode blockSize; 
+                [PacketField, Offset(doubleWords: 0, bits: 29), Width(1)]
+                public bool priority; 
+                [PacketField, Offset(doubleWords: 0, bits: 30), Width(1)]
+                public bool SRCREQSELB5; 
+                [PacketField, Offset(doubleWords: 0, bits: 31), Width(1)]
+                public bool DSTREQSELB5; 
+                [PacketField, Offset(doubleWords: 1, bits: 0), Width(32)]
+                public uint sourceAddress;        
+                [PacketField, Offset(doubleWords: 2, bits: 0), Width(32)]
+                public uint destinationAddress;   
+                [PacketField, Offset(doubleWords: 3, bits: 0), Width(22)]
+                public uint TranSize;    
+                [PacketField, Offset(doubleWords: 4, bits: 2), Width(30)]
+                public uint linkAddress;
+#pragma warning restore 649
+            }
+        }
+    }
+}

--- a/src/Emulator/Peripherals/Peripherals/DMA/ATCDMAC100.cs
+++ b/src/Emulator/Peripherals/Peripherals/DMA/ATCDMAC100.cs
@@ -529,7 +529,7 @@ namespace Antmicro.Renode.Peripherals.DMA
 }}";
 
                 
-                // bits : starting position w.r.t register
+// bits : starting position w.r.t register
 #pragma warning disable 649
                 [PacketField, Offset(doubleWords: 0, bits: 0), Width(1)]
                 public bool Enabled;

--- a/src/Emulator/Peripherals/Peripherals/DMA/ATCDMAC100.cs
+++ b/src/Emulator/Peripherals/Peripherals/DMA/ATCDMAC100.cs
@@ -376,14 +376,14 @@ namespace Antmicro.Renode.Peripherals.DMA
                 do
                 {    
                     var blockSizeMultiplier = Math.Min(TranSize, BlockSizeMultiplier);
-                  /*  if (descriptor.SrcAddrCtrl==AddressMode.Decrement)
+                    if (descriptor.SrcAddrCtrl==AddressMode.Decrement)
                     {
                     descriptor.sourceAddress -= SourceIncrement * blockSizeMultiplier;
                     }
                     if (descriptor.DstAddrCtrl==AddressMode.Decrement)
                     {
                     descriptor.destinationAddress -= DestinationIncrement * blockSizeMultiplier;
-                    }*/
+                    }
                 
 
                     var request = new Request(
@@ -394,10 +394,10 @@ namespace Antmicro.Renode.Peripherals.DMA
                         writeTransferType: SizeAsTransferType,
                         sourceIncrementStep: SourceIncrement,
                         destinationIncrementStep: DestinationIncrement,
-                        incrementReadAddress:true,  //source
-                        incrementWriteAddress:false,  //destination
-                        decrementReadAddress:false,  //source
-                        decrementWriteAddress:true  //destination
+                        incrementReadAddress:true,  //source increment
+                        incrementWriteAddress:false,  //destination increment
+                        decrementReadAddress:false,  //source increment
+                        decrementWriteAddress:true  //destination decrement
 
                     );
                     
@@ -412,14 +412,7 @@ namespace Antmicro.Renode.Peripherals.DMA
                     {
                         descriptor.TranSize -= blockSizeMultiplier;
                     }
-                   if (descriptor.SrcAddrCtrl==AddressMode.Decrement)
-                    {
-                    descriptor.sourceAddress -= SourceIncrement * blockSizeMultiplier;
-                    }
-                    if (descriptor.DstAddrCtrl==AddressMode.Decrement)
-                    {
-                    descriptor.destinationAddress -= DestinationIncrement * blockSizeMultiplier;
-                    }
+                   
                     if ((descriptor.SrcAddrCtrl==AddressMode.Increment) || (descriptor.SrcAddrCtrl==AddressMode.Fixed))
                      {
                         descriptor.sourceAddress += SourceIncrement * blockSizeMultiplier;

--- a/src/Emulator/Peripherals/Peripherals/DMA/ATCDMAC100.cs
+++ b/src/Emulator/Peripherals/Peripherals/DMA/ATCDMAC100.cs
@@ -394,10 +394,16 @@ namespace Antmicro.Renode.Peripherals.DMA
                         writeTransferType: SizeAsTransferType,
                         sourceIncrementStep: SourceIncrement,
                         destinationIncrementStep: DestinationIncrement,
-                        incrementReadAddress:false,  //source increment
+                       /* incrementReadAddress:false,  //source increment
                         incrementWriteAddress:true,  //destination increment
-                        decrementReadAddress:true,  //source increment
-                        decrementWriteAddress:false  //destination decrement
+                        decrementReadAddress:true,  //source decrement
+                        decrementWriteAddress:false  //destination decrement*/
+
+                        incrementReadAddress:SourceInc,  //source increment
+                        incrementWriteAddress:DestinationInc,  //destination increment
+                        decrementReadAddress:SourceDec,  //source dec
+                        decrementWriteAddress:DestinationDec  //destination decrement
+
 
                     );
                     
@@ -462,6 +468,53 @@ namespace Antmicro.Renode.Peripherals.DMA
             private uint DestinationIncrement => descriptor.DstAddrCtrl == AddressMode.Fixed ? 0u : ((1u << (byte)descriptor.dstwidth));
             private TransferType SizeAsTransferType => (TransferType)(1 << (byte)descriptor.srcwidth);
             private int Bytes => (int)Math.Min(TranSize, BlockSizeMultiplier) << (byte)descriptor.srcwidth;
+            private bool SourceMode
+            {
+               set 
+                {
+                  if (descriptor.SrcAddrCtrl==AddressMode.Increment) 
+                  {
+                       SourceInc=true;
+                       SourceDec=false;
+                  }
+                  if (descriptor.SrcAddrCtrl==AddressMode.Decrement) 
+                  {
+                       SourceInc=false;
+                       SourceDec=true;
+                  }
+
+                }
+
+            } 
+            private bool DestinationMode
+            {
+               set 
+                {
+                  if (descriptor.DstAddrCtrl==AddressMode.Increment) 
+                  {
+                       DestinationInc=true;
+                       DestinationDec=false;
+                  }
+                  if (descriptor.SrcAddrCtrl==AddressMode.Decrement) 
+                  {
+                       DestinationInc=false;
+                       DestinationDec=true;
+                  }
+
+                }
+
+            } 
+           // private bool SourceDec =>  if (descriptor.SrcAddrCtrl==AddressMode.Decrement)  {SourceDec=false;}
+                
+           public bool SourceInc;
+           public bool SourceDec;
+
+            public bool DestinationInc;
+             public bool DestinationDec;
+            
+
+
+            private bool DestinationMode => descriptor.DstAddrCtrl;
 
             private Descriptor descriptor;
             private ulong? descriptorAddress;

--- a/src/Emulator/Peripherals/Peripherals/DMA/ATCDMAC100.cs
+++ b/src/Emulator/Peripherals/Peripherals/DMA/ATCDMAC100.cs
@@ -468,7 +468,7 @@ namespace Antmicro.Renode.Peripherals.DMA
             private uint DestinationIncrement => descriptor.DstAddrCtrl == AddressMode.Fixed ? 0u : ((1u << (byte)descriptor.dstwidth));
             private TransferType SizeAsTransferType => (TransferType)(1 << (byte)descriptor.srcwidth);
             private int Bytes => (int)Math.Min(TranSize, BlockSizeMultiplier) << (byte)descriptor.srcwidth;
-            private bool SourceMode
+           /* private bool SourceMode
             {
                set 
                 {
@@ -510,8 +510,13 @@ namespace Antmicro.Renode.Peripherals.DMA
            public bool SourceDec;
 
             public bool DestinationInc;
-             public bool DestinationDec;
-            
+             public bool DestinationDec;*/
+
+       private bool SourceInc => descriptor.SrcAddrCtrl == AddressMode.Increment;
+       private bool SourceDec => descriptor.SrcAddrCtrl == AddressMode.Decrement;
+
+     private bool DestinationInc => descriptor.DstAddrCtrl == AddressMode.Increment;
+       private bool DestinationDec => descriptor.DstAddrCtrl == AddressMode.Decrement;    
 
 
            

--- a/src/Emulator/Peripherals/Peripherals/DMA/ATCDMAC100.cs
+++ b/src/Emulator/Peripherals/Peripherals/DMA/ATCDMAC100.cs
@@ -376,14 +376,14 @@ namespace Antmicro.Renode.Peripherals.DMA
                 do
                 {    
                     var blockSizeMultiplier = Math.Min(TranSize, BlockSizeMultiplier);
-                    if (descriptor.SrcAddrCtrl==AddressMode.Decrement)
+                  /*  if (descriptor.SrcAddrCtrl==AddressMode.Decrement)
                     {
                     descriptor.sourceAddress -= SourceIncrement * blockSizeMultiplier;
                     }
                     if (descriptor.DstAddrCtrl==AddressMode.Decrement)
                     {
                     descriptor.destinationAddress -= DestinationIncrement * blockSizeMultiplier;
-                    }
+                    }*/
                 
 
                     var request = new Request(
@@ -412,7 +412,14 @@ namespace Antmicro.Renode.Peripherals.DMA
                     {
                         descriptor.TranSize -= blockSizeMultiplier;
                     }
-                   
+                   if (descriptor.SrcAddrCtrl==AddressMode.Decrement)
+                    {
+                    descriptor.sourceAddress -= SourceIncrement * blockSizeMultiplier;
+                    }
+                    if (descriptor.DstAddrCtrl==AddressMode.Decrement)
+                    {
+                    descriptor.destinationAddress -= DestinationIncrement * blockSizeMultiplier;
+                    }
                     if ((descriptor.SrcAddrCtrl==AddressMode.Increment) || (descriptor.SrcAddrCtrl==AddressMode.Fixed))
                      {
                         descriptor.sourceAddress += SourceIncrement * blockSizeMultiplier;

--- a/src/Emulator/Peripherals/Peripherals/DMA/ATCDMAC100.cs
+++ b/src/Emulator/Peripherals/Peripherals/DMA/ATCDMAC100.cs
@@ -394,10 +394,10 @@ namespace Antmicro.Renode.Peripherals.DMA
                         writeTransferType: SizeAsTransferType,
                         sourceIncrementStep: SourceIncrement,
                         destinationIncrementStep: DestinationIncrement,
-                        incrementReadAddress:true,  //source increment
-                        incrementWriteAddress:false,  //destination increment
-                        decrementReadAddress:false,  //source increment
-                        decrementWriteAddress:true  //destination decrement
+                        incrementReadAddress:false,  //source increment
+                        incrementWriteAddress:true,  //destination increment
+                        decrementReadAddress:true,  //source increment
+                        decrementWriteAddress:false  //destination decrement
 
                     );
                     

--- a/src/Emulator/Peripherals/Peripherals/GPIOPort/Virgo_pad.cs
+++ b/src/Emulator/Peripherals/Peripherals/GPIOPort/Virgo_pad.cs
@@ -1,0 +1,945 @@
+//
+// Copyright (c) 2010-2023 Antmicro
+//
+//  This file is licensed under the MIT License.
+//  Full license text is available in 'licenses/MIT.txt'.
+//
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Runtime.InteropServices;
+using Antmicro.Renode.Exceptions;
+using Antmicro.Renode.Logging;
+using System.Linq;
+using Antmicro.Renode.Core;
+using Antmicro.Renode.Core.Structure.Registers;
+using Antmicro.Renode.Peripherals.Bus;
+using Antmicro.Renode.Utilities;
+using static Antmicro.Renode.Peripherals.GPIOPort.ATCGPIO100;
+//using Antmicro.Renode.Peripherals.GPIOPort;
+
+namespace Antmicro.Renode.Peripherals.GPIOPort
+{
+    public class Virgo_pad : BaseGPIOPort, IProvidesRegisterCollection<DoubleWordRegisterCollection>, IDoubleWordPeripheral, IKnownSize,IGPIOReceiver
+    {
+        public Virgo_pad(IMachine machine) : base(machine, NumberOfGPIOs)
+        {
+            
+         RegistersCollection = new DoubleWordRegisterCollection(this);
+         PrepareRegisters();
+        }
+
+        public override void Reset()
+        {
+                base.Reset();
+        }
+
+        
+        public DoubleWordRegisterCollection RegistersCollection { get; }
+        public long Size => 0x1000;
+        public uint ReadDoubleWord(long offset)
+        {
+            return RegistersCollection.Read(offset);
+        }
+
+        public void WriteDoubleWord(long offset, uint value)
+        {  
+          if(offset >= (long)Registers.std_pu_PAD_GPIO_A_0_ctl && offset <= (long)Registers.std_pu_PAD_GPIO_A_15_ctl)
+            if(!registerunlocked)
+                {
+                    this.Log(LogLevel.Warning, "Tried to change pin configuration register which is locked. PADKEY value: {0:X}", padKey);
+                    this.InfoLog("registeunlocked {0}", registerunlocked);
+                    return;
+                }
+                this.InfoLog("pads unlocked");
+            RegistersCollection.Write(offset, value);
+        }
+        
+        public override void OnGPIO(int number, bool value)
+        {
+            if(!CheckPinNumber(number))
+            {
+                return;
+            }
+            
+            base.OnGPIO(number, value);
+            this.InfoLog("Setting pad number #{0} to value {1}", number, value);
+             
+            pin = pinstate(value);
+            
+            // var currentValue = State[number];  
+           switch(number) {
+            	case 0:
+              	if(EN_0) {
+                	switch(MUX_0) {
+                  	case 1: 
+                    	OnPinStateChanged(number+16, value);
+                        break;
+                    case 2:
+                    	OnPinStateChanged(number+32, value);
+                        break;
+                    case 3:
+                        OnPinStateChanged(number+48, value);
+                        break;
+                    case 4:
+                        OnPinStateChanged(number+64, value);
+                        break;
+                    default:
+                    	break;
+                  }
+                }
+                break;
+                
+                case 1:
+                	if(EN_1) {
+                  	switch(MUX_1) {
+                    case 1:
+                        OnPinStateChanged(number+16, value);
+                        break;
+                    case 2:
+                      	OnPinStateChanged(number+32, value);
+                        break;
+                    case 3:
+                        OnPinStateChanged(number+48, value);
+                        break;
+                    case 4:
+                        OnPinStateChanged(number+64, value);
+                        break;
+                    default:
+                      	break;
+                    }
+                  }
+                break;
+
+                case 2:
+                	if(EN_2) {
+                  	switch(MUX_2) {
+                    case 1:
+                        break;
+                    case 2:
+                      	OnPinStateChanged(number+32, value);
+                        break;
+                    case 3:
+                        break;
+                    case 4:
+                        break;
+                    default:
+                      	break;
+                    }
+                  }
+                break; 
+
+                case 3:
+                	if(EN_3) {
+                  	switch(MUX_3) {
+                    case 1:
+                        break;
+                    case 2:
+                      	OnPinStateChanged(number+32, value);
+                        break;
+                    case 3:
+                        break;
+                    case 4:
+                        break;
+                    default:
+                      	break;
+                    }
+                  }
+                break;
+
+                case 4:
+                	if(EN_4) {
+                  	switch(MUX_4) {
+                    case 1:
+                        break;
+                    case 2:
+                      	OnPinStateChanged(number+32, value);
+                        break;
+                    case 3:
+                        break;
+                    case 4:
+                        OnPinStateChanged(number+64, value);
+                        break;
+                    default:
+                      	break;
+                    }
+                  }
+                break;
+
+                case 5:
+                	if(EN_5) {
+                  	switch(MUX_5) {
+                    case 1:
+                        break;
+                    case 2:
+                      	OnPinStateChanged(number+32, value);
+                        break;
+                    case 3:
+                        break;
+                    case 4:
+                        OnPinStateChanged(number+64, value);
+                        break;
+                    default:
+                      	break;
+                    }
+                  }
+                break;
+
+                case 6:
+                	if(EN_6) {
+                  	switch(MUX_6) {
+                    case 1:
+                        break;
+                    case 2:
+                      	OnPinStateChanged(number+32, value);
+                        break;
+                    case 3:
+                        break;
+                    case 4:
+                        OnPinStateChanged(number+64, value);
+                        break;
+                    default:
+                      	break;
+                    }
+                  }
+                break;
+
+                case 7:
+                	if(EN_7) {
+                  	switch(MUX_7) {
+                    case 1:
+                        break;
+                    case 2:
+                      	OnPinStateChanged(number+32, value);
+                        break;
+                    case 3:
+                        break;
+                    case 4:
+                        OnPinStateChanged(number+64, value);
+                        break;
+                    default:
+                      	break;
+                    }
+                  }
+                break;
+            
+                case 8:
+                	if(EN_8) {
+                  	switch(MUX_8) {
+                    case 1:
+                        break;
+                    case 2:
+                      	OnPinStateChanged(number+32, value);
+                        break;
+                    case 3:
+                        break;
+                    case 4:
+                        OnPinStateChanged(number+64, value);
+                        break;
+                    default:
+                      	break;
+                    }
+                  }
+                break;
+                
+                case 9:
+                	if(EN_9) {
+                  	switch(MUX_10) {
+                    case 1:
+                        break;
+                    case 2:
+                      	OnPinStateChanged(number+32 , value);
+                        break;
+                    case 3:
+                        break;
+                    case 4:
+                        OnPinStateChanged(number+64, value);
+                        break;
+                    default:
+                      	break;
+                    }
+                  }
+                break;
+
+                case 10:
+                	if(EN_10) {
+                  	switch(MUX_10) {
+                    case 1:
+                        OnPinStateChanged(number+16, value);
+                        break;
+                    case 2:
+                      	OnPinStateChanged(number+32, value);
+                        break;
+                    case 3:
+                        OnPinStateChanged(number+48, value);
+                        break;
+                    case 4:
+                        break;
+                    default:
+                      	break;
+                    }
+                  }
+                break;
+
+                case 11:
+                	if(EN_11) {
+                  	switch(MUX_11) {
+                    case 1:
+                        OnPinStateChanged(number+16, value);
+                        break;
+                    case 2:
+                      	OnPinStateChanged(number+32, value);
+                        break;
+                    case 3:
+                        OnPinStateChanged(number+48, value);
+                        break;
+                    case 4:
+                        break;
+                    default:
+                      	break;
+                    }
+                  }
+                break;
+
+                case 12:
+                	if(EN_12) {
+                  	switch(MUX_12) {
+                    case 1:
+                        OnPinStateChanged(number+16, value);
+                        break;
+                    case 2:
+                      	OnPinStateChanged(number+32, value);
+                        break;
+                    case 3:
+                        OnPinStateChanged(number+48, value);
+                        break;
+                    case 4:
+                        break;
+                    default:
+                      	break;
+                    }
+                  }
+                break;
+                
+                case 13:
+                	if(EN_13) {
+                  	switch(MUX_13) {
+                    case 1:
+                        OnPinStateChanged(number+16, value);
+                        break;
+                    case 2:
+                      	OnPinStateChanged(number+32, value);
+                        break;
+                    case 3:
+                        OnPinStateChanged(number+48, value);
+                        break;
+                    case 4:
+                        break;
+                    default:
+                      	break;
+                    }
+                  }
+                break;
+
+                case 14:
+                	if(EN_14) {
+                  	switch(MUX_14) {
+                    case 1:
+                        OnPinStateChanged(number+16, value);
+                        break;
+                    case 2:
+                      	OnPinStateChanged(number+32, value);
+                        break;
+                    case 3:
+                        OnPinStateChanged(number+48, value);
+                        break;
+                    case 4:
+                        break;
+                    default:
+                      	break;
+                    }
+                  }
+                break;
+
+                case 15:
+                	if(EN_15) {
+                  	switch(MUX_15) {
+                    case 1:
+                        OnPinStateChanged(number+16, value);
+                        break;
+                    case 2:
+                      	OnPinStateChanged(number+32, value);
+                        break;
+                    case 3:
+                        OnPinStateChanged(number+48, value);
+                        break;
+                    case 4:
+                        break;
+                    default:
+                      	break;
+                    }
+                  }
+                break;
+
+                case 16:
+                	if(EN_0 && (MUX_0 == 1)) {
+                  	OnPinStateChanged(number-16, value);
+                  }
+                  break;
+                
+                case 17:
+                	if(EN_1 && (MUX_1 == 1)) {
+                  	OnPinStateChanged(number-16, value);
+                  }
+                  break;
+
+                case 26:
+                	if(EN_10 && (MUX_10 == 1)) {
+                  	OnPinStateChanged(number-16, value);
+                  }
+                  break;
+
+                case 27:
+                	if(EN_11 && (MUX_11 == 1)) {
+                  	OnPinStateChanged(number-16, value);
+                  }
+                  break;
+                
+                case 28:
+                	if(EN_12 && (MUX_12 == 1)) {
+                  	OnPinStateChanged(number-16, value);
+                  }
+                  break;
+
+                case 29:
+                	if(EN_13 && (MUX_13 == 1)) {
+                  	OnPinStateChanged(number-16, value);
+                  }
+                  break;
+                
+                case 30:
+                	if(EN_14 && (MUX_14 == 1)) {
+                  	OnPinStateChanged(number-16, value);
+                  }
+                  break;
+                
+                case 31:
+                	if(EN_15 && (MUX_15 == 1)) {
+                  	OnPinStateChanged(number-16, value);
+                  }
+                  break;
+
+                case 32:
+                	if(EN_0 && (MUX_0 == 2)) {
+                  	OnPinStateChanged(number-32, value);
+                  }
+                  break;
+                
+                case 33:
+                	if(EN_1 && (MUX_1 == 2)) {
+                  	OnPinStateChanged(number-32, value);
+                  }
+                  break;
+
+                case 34:
+                	if(EN_2 && (MUX_2 == 2)) {
+                  	OnPinStateChanged(number-32, value);
+                  }
+                  break;
+                
+                case 35:
+                	if(EN_3 && (MUX_3 == 2)) {
+                  	OnPinStateChanged(number-32, value);
+                  }
+                  break;
+                
+                case 36:
+                	if(EN_4 && (MUX_4 == 2)) {
+                  	OnPinStateChanged(number-32, value);
+                  }
+                  break;
+
+                case 37:
+                	if(EN_5 && (MUX_5 == 2)) {
+                  	OnPinStateChanged(number-32, value);
+                  }
+                  break;
+            
+                case 38:
+                	if(EN_6 && (MUX_6 == 2)) {
+                  	OnPinStateChanged(number-32, value);
+                  }
+                  break;
+                
+                case 39:
+                	if(EN_7 && (MUX_7 == 2)) {
+                  	OnPinStateChanged(number-32, value);
+                  }
+                  break;
+                
+                case 40:
+                	if(EN_8 && (MUX_8 == 2)) {
+                  	OnPinStateChanged(number-32, value);
+                  }
+                  break;
+                
+                case 41:
+                	if(EN_9 && (MUX_9 == 2)) {
+                  	OnPinStateChanged(number-32, value);
+                  }
+                  break;
+                
+                case 42:
+                	if(EN_10 && (MUX_10 == 2)) {
+                  	OnPinStateChanged(number-32, value);
+                  }
+                  break;
+
+                case 43:
+                	if(EN_11 && (MUX_11 == 2)) {
+                  	OnPinStateChanged(number-32, value);
+                  }
+                  break;
+
+                case 44:
+                	if(EN_12 && (MUX_12 == 2)) {
+                  	OnPinStateChanged(number-32, value);
+                  }
+                  break;
+
+                case 45:
+                	if(EN_13 && (MUX_13 == 2)) {
+                  	OnPinStateChanged(number-32, value);
+                  }
+                  break;
+
+                case 46:
+                	if(EN_14 && (MUX_14 == 2)) {
+                  	OnPinStateChanged(number-32, value);
+                  }
+                  break;
+
+                case 47:
+                	if(EN_15 && (MUX_15 == 2)) {
+                  	OnPinStateChanged(number-32, value);
+                  }
+                  break;
+                
+                case 48:
+                	if(EN_0 && (MUX_0 == 3)) {
+                  	OnPinStateChanged(number-48, value);
+                  }
+                  break;
+
+                case 49:
+                	if(EN_1 && (MUX_1 == 3)) {
+                  	OnPinStateChanged(number-48, value);
+                  }
+                  break;
+                
+                case 58:
+                	if(EN_10 && (MUX_10 == 3)) {
+                  	OnPinStateChanged(number-48, value);
+                  }
+                  break;
+                
+                case 59:
+                	if(EN_11 && (MUX_11 == 3)) {
+                  	OnPinStateChanged(number-48, value);
+                  }
+                  break;
+                
+                case 60:
+                	if(EN_12 && (MUX_12 == 3)) {
+                  	OnPinStateChanged(number-48, value);
+                  }
+                  break;
+
+                case 61:
+                	if(EN_13 && (MUX_13 == 3)) {
+                  	OnPinStateChanged(number-48, value);
+                  }
+                  break;
+
+                case 62:
+                	if(EN_14 && (MUX_14 == 3)) {
+                  	OnPinStateChanged(number-48, value);
+                  }
+                  break;
+
+                case 63:
+                	if(EN_15 && (MUX_15 == 3)) {
+                  	OnPinStateChanged(number-48, value);
+                  }
+                  break;
+
+                case 64:
+                	if(EN_0 && (MUX_0 == 4)) {
+                  	OnPinStateChanged(number-64, value);
+                  }
+                  break;
+                
+                case 65:
+                	if(EN_1 && (MUX_1 == 4)) {
+                  	OnPinStateChanged(number-64, value);
+                  }
+                  break;
+                 
+                case 68:
+                	if(EN_4 && (MUX_4 == 4)) {
+                  	OnPinStateChanged(number-64, value);
+                  }
+                  break;
+
+                case 69:
+                	if(EN_5 && (MUX_5 == 4)) {
+                  	OnPinStateChanged(number-64, value);
+                  }
+                  break;
+                
+                case 70:
+                	if(EN_6 && (MUX_6 == 4)) {
+                  	OnPinStateChanged(number-64, value);
+                  }
+                  break;
+
+                case 71:
+                	if(EN_7 && (MUX_7 == 4)) {
+                  	OnPinStateChanged(number-64, value);
+                  }
+                  break;
+                
+                case 72:
+                	if(EN_8 && (MUX_8 == 4)) {
+                  	OnPinStateChanged(number-64, value);
+                  }
+                  break;
+
+                case 73:
+                	if(EN_9 && (MUX_9 == 4)) {
+                  	OnPinStateChanged(number-64, value);
+                  }
+                  break;
+
+            }
+                      
+        } 
+
+          private void OnPinStateChanged(int number, bool current)
+        {    
+            Connections[number].Set(pin);
+        }
+
+        public bool pinstate(bool value){
+            if(value)
+            return true;
+            else 
+            return false;
+        }
+
+           private uint selection(IOMode value)
+            {
+                
+                switch((IOMode)value)
+                {
+                case IOMode.MainMode:               
+                this.InfoLog("mode 1");    
+                return 1;            
+                case IOMode.Fpga_pinMode:             
+                this.InfoLog("mode 2");
+                return 2; 
+                case IOMode.AlternativeMode:
+                this.InfoLog("mode 3"); 
+                return 3;
+                case IOMode.DebugMode:
+                this.InfoLog("mode 4"); 
+                return 4;
+                default:
+                    this.InfoLog(" Non existitng possible value written as selection lines.");
+                return 0;
+                }
+            }
+        private void PrepareRegisters()
+        {
+                Registers.pad_csr.Define(this)
+               // .WithTaggedFlag("STATUS",0)
+                 //.WithReservedBits(0, 1)
+                .WithValueField(0, 31,FieldMode.Read|FieldMode.Write , name: "PADKEY",writeCallback: ( _, value) => {
+                  if (value==PadKeyUnlockValue)
+                   registerunlocked=true;
+                    this.InfoLog("registeunlocked in register {0}", registerunlocked); }
+                  )
+                  .WithTaggedFlag("STATUS",31)
+                ; 
+                
+                Registers.std_pu_PAD_GPIO_A_0_ctl.Define(this)
+                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN_0=value)
+                .WithTag("DS", 1, 2)
+                .WithReservedBits(3, 2)
+                .WithTaggedFlag("PUE", 5)
+                .WithTaggedFlag("PUD", 6)
+                .WithEnumField<DoubleWordRegister, IOMode>(7, 2,               
+                writeCallback: (_, value) =>  {
+
+                    MUX_0=selection((IOMode)value);
+                    },  
+                name: "FUNCMAX")
+                .WithReservedBits(9, 23) 
+
+                ;
+                
+                Registers.std_pu_PAD_GPIO_A_1_ctl.Define(this)
+                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN_1=value)
+                .WithTag("DS", 1, 2)
+                .WithReservedBits(3, 2)
+                .WithTaggedFlag("PUE", 5)
+                .WithTaggedFlag("PUD", 6)
+                .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
+                writeCallback: (_, value) =>  {
+                    MUX_1=selection((IOMode)value);
+                    },
+                name: "FUNCMAX")
+                .WithReservedBits(9, 23) 
+                
+            ;  
+
+                Registers.std_pu_PAD_GPIO_A_2_ctl.Define(this)
+                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN_2=value)
+                .WithTag("DS", 1, 2)
+                .WithReservedBits(3, 2)
+                .WithTaggedFlag("PUE", 5)
+                .WithTaggedFlag("PUD", 6)
+                .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
+                writeCallback: (_, value) =>  {
+                    MUX_2=selection((IOMode)value);
+                    },
+                name: "FUNCMAX")
+                .WithReservedBits(9, 23) 
+                
+            ;  
+                Registers.std_pu_PAD_GPIO_A_3_ctl.Define(this)
+                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN_3=value)
+                .WithTag("DS", 1, 2)
+                .WithReservedBits(3, 2)
+                .WithTaggedFlag("PUE", 5)
+                .WithTaggedFlag("PUD", 6)
+                .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
+                writeCallback: (_, value) =>  {
+                    MUX_3=selection((IOMode)value);
+                    },
+                name: "FUNCMAX")
+                .WithReservedBits(9, 23) 
+                
+            ; 
+            Registers.std_pu_PAD_GPIO_A_4_ctl.Define(this)
+                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN_4=value)
+                .WithTag("DS", 1, 2)
+                .WithReservedBits(3, 2)
+                .WithTaggedFlag("PUE", 5)
+                .WithTaggedFlag("PUD", 6)
+                .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
+                writeCallback: (_, value) =>  {
+                    MUX_4=selection((IOMode)value);
+                    },
+                name: "FUNCMAX")
+                .WithReservedBits(9, 23) 
+                
+            ;
+            Registers.std_pu_PAD_GPIO_A_5_ctl.Define(this)
+                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN_5=value)
+                .WithTag("DS", 1, 2)
+                .WithReservedBits(3, 2)
+                .WithTaggedFlag("PUE", 5)
+                .WithTaggedFlag("PUD", 6)
+                .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
+                writeCallback: (_, value) =>  {
+                    MUX_5=selection((IOMode)value);
+                    },
+                name: "FUNCMAX")
+                .WithReservedBits(9, 23) 
+                
+            ;
+            Registers.std_pu_PAD_GPIO_A_6_ctl.Define(this)
+                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN_6=value)
+                .WithTag("DS", 1, 2)
+                .WithReservedBits(3, 2)
+                .WithTaggedFlag("PUE", 5)
+                .WithTaggedFlag("PUD", 6)
+                .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
+                writeCallback: (_, value) =>  {
+                    MUX_6=selection((IOMode)value);
+                    },
+                name: "FUNCMAX")
+                .WithReservedBits(9, 23) 
+                
+            ;
+            Registers.std_pu_PAD_GPIO_A_7_ctl.Define(this)
+                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN_7=value)
+                .WithTag("DS", 1, 2)
+                .WithReservedBits(3, 2)
+                .WithTaggedFlag("PUE", 5)
+                .WithTaggedFlag("PUD", 6)
+                .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
+                writeCallback: (_, value) =>  {
+                    MUX_7=selection((IOMode)value);
+                    },
+                name: "FUNCMAX")
+                .WithReservedBits(9, 23) 
+                
+            ;
+            Registers.std_pu_PAD_GPIO_A_8_ctl.Define(this)
+                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN_8=value)
+                .WithTag("DS", 1, 2)
+                .WithReservedBits(3, 2)
+                .WithTaggedFlag("PUE", 5)
+                .WithTaggedFlag("PUD", 6)
+                .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
+                writeCallback: (_, value) =>  {
+                    MUX_8=selection((IOMode)value);
+                    },
+                name: "FUNCMAX")
+                .WithReservedBits(9, 23) 
+                
+            ;
+            Registers.std_pu_PAD_GPIO_A_9_ctl.Define(this)
+                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN_9=value)
+                .WithTag("DS", 1, 2)
+                .WithReservedBits(3, 2)
+                .WithTaggedFlag("PUE", 5)
+                .WithTaggedFlag("PUD", 6)
+                .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
+                writeCallback: (_, value) =>  {
+                    MUX_9=selection((IOMode)value);
+                    },
+                name: "FUNCMAX")
+                .WithReservedBits(9, 23) 
+                
+            ;
+             Registers.std_pu_PAD_GPIO_A_10_ctl.Define(this)
+                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN_10=value)
+                .WithTag("DS", 1, 2)
+                .WithReservedBits(3, 2)
+                .WithTaggedFlag("PUE", 5)
+                .WithTaggedFlag("PUD", 6)
+                .WithEnumField<DoubleWordRegister, IOMode>(7, 2, 
+                writeCallback: (_, value) =>  {
+                    MUX_10=selection((IOMode)value);
+                    },
+                
+                name: "FUNCMAX")
+                .WithReservedBits(9, 23) 
+                
+            ;  
+            Registers.std_pu_PAD_GPIO_A_11_ctl.Define(this)
+                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN_11=value)
+                .WithTag("DS", 1, 2)
+                .WithReservedBits(3, 2)
+                .WithTaggedFlag("PUE", 5)
+                .WithTaggedFlag("PUD", 6)
+                .WithEnumField<DoubleWordRegister, IOMode>(7, 2,  
+                writeCallback: (_, value) =>  {
+                    MUX_11=selection((IOMode)value);
+                    },
+                name: "FUNCMAX")
+                .WithReservedBits(9, 23) 
+                
+            ;  
+
+            Registers.std_pu_PAD_GPIO_A_12_ctl.Define(this)
+                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN_12=value)
+                .WithTag("DS", 1, 2)
+                .WithReservedBits(3, 2)
+                .WithTaggedFlag("PUE", 5)
+                .WithTaggedFlag("PUD", 6)
+                .WithEnumField<DoubleWordRegister, IOMode>(7, 2,  
+                writeCallback: (_, value) =>  {
+                MUX_12=selection((IOMode)value);
+                    },
+                
+                name: "FUNCMAX")
+                .WithReservedBits(9, 23) 
+                
+            ;  
+
+            Registers.std_pu_PAD_GPIO_A_13_ctl.Define(this)
+                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN_13=value)
+                .WithTag("DS", 1, 2)
+                .WithReservedBits(3, 2)
+                .WithTaggedFlag("PUE", 5)
+                .WithTaggedFlag("PUD", 6)
+                .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
+                writeCallback: (_, value) =>  {
+                    MUX_13=selection((IOMode)value);
+                    },
+                name: "FUNCMAX")
+                .WithReservedBits(9, 23) 
+                
+            ;
+            Registers.std_pu_PAD_GPIO_A_14_ctl.Define(this)
+                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN_14=value)
+                .WithTag("DS", 1, 2)
+                .WithReservedBits(3, 2)
+                .WithTaggedFlag("PUE", 5)
+                .WithTaggedFlag("PUD", 6)
+                .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
+                writeCallback: (_, value) =>  {
+                    MUX_14=selection((IOMode)value);
+                    },
+                name: "FUNCMAX")
+                .WithReservedBits(9, 23) 
+                
+            ;
+            Registers.std_pu_PAD_GPIO_A_15_ctl.Define(this)
+                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN_15=value)
+                .WithTag("DS", 1, 2)
+                .WithReservedBits(3, 2)
+                .WithTaggedFlag("PUE", 5)
+                .WithTaggedFlag("PUD", 6)
+                .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
+                writeCallback: (_, value) =>  {
+                    MUX_15=selection((IOMode)value);
+                    },
+                name: "FUNCMAX")
+                .WithReservedBits(9, 23) 
+                
+            ;
+
+        }
+       
+        public bool pin;
+        private uint MUX_0,MUX_1,MUX_2, MUX_3, MUX_4, MUX_5, MUX_6, MUX_7 , MUX_8 , MUX_9 ,MUX_10,MUX_11, MUX_12,MUX_13,MUX_14,MUX_15;
+        private bool EN_0,EN_1,EN_2,EN_3,EN_4,EN_5,EN_6,EN_7,EN_8,EN_9,EN_10,EN_11,EN_12,EN_13,EN_14,EN_15;
+        private const int NumberOfGPIOs = 80;
+        private uint padKey;
+        public const uint PadKeyUnlockValue = 0x2A6;
+        public bool registerunlocked=false;
+
+         public enum IOMode
+        {   MainMode = 0, 
+            Fpga_pinMode = 1, 
+            AlternativeMode = 2, 
+            DebugMode = 3
+        }
+ 
+        private enum Registers
+        {
+            pad_csr = 0x1000,
+            std_pu_PAD_GPIO_A_0_ctl = 0x1004,
+            std_pu_PAD_GPIO_A_1_ctl = 0x1008,
+            std_pu_PAD_GPIO_A_2_ctl = 0x100C,
+            std_pu_PAD_GPIO_A_3_ctl = 0x1010,
+            std_pu_PAD_GPIO_A_4_ctl = 0x1014,
+            std_pu_PAD_GPIO_A_5_ctl = 0x1018,
+            std_pu_PAD_GPIO_A_6_ctl = 0x101C,
+            std_pu_PAD_GPIO_A_7_ctl = 0x1020,
+            std_pu_PAD_GPIO_A_8_ctl = 0x1024,
+            std_pu_PAD_GPIO_A_9_ctl = 0x1028,
+            std_pu_PAD_GPIO_A_10_ctl = 0x102C ,
+            std_pu_PAD_GPIO_A_11_ctl = 0x1030,
+            std_pu_PAD_GPIO_A_12_ctl = 0x1034,
+            std_pu_PAD_GPIO_A_13_ctl = 0x1038,
+            std_pu_PAD_GPIO_A_14_ctl = 0x103C,
+            std_pu_PAD_GPIO_A_15_ctl = 0x1040
+        }
+    }
+}

--- a/src/Emulator/Peripherals/Peripherals/GPIOPort/Virgo_pad.cs
+++ b/src/Emulator/Peripherals/Peripherals/GPIOPort/Virgo_pad.cs
@@ -23,30 +23,25 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
     public class Virgo_pad : BaseGPIOPort, IProvidesRegisterCollection<DoubleWordRegisterCollection>, IDoubleWordPeripheral, IKnownSize,IGPIOReceiver
     {
         public Virgo_pad(IMachine machine) : base(machine, NumberOfGPIOs)
-        {
-            
+        {    
          RegistersCollection = new DoubleWordRegisterCollection(this);
          PrepareRegisters();
-         //InternalRegisters();
         }
 
         public override void Reset()
         {
-                base.Reset();
+          base.Reset();
         }
-
-        
+  
         public DoubleWordRegisterCollection RegistersCollection { get; }
         public long Size => 0x1000;
         public uint ReadDoubleWord(long offset)
         {
-            return RegistersCollection.Read(offset);
+          return RegistersCollection.Read(offset);
         }
-         
-        
+              
         public void WriteDoubleWord(long offset, uint value)
-        {  
-          
+        {    
          RegistersCollection.Write(offset, value);
         }
         
@@ -54,15 +49,11 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
         {
             if(!CheckPinNumber(number))
             {
-                return;
+              return;
             }
             
             base.OnGPIO(number, value);
-            this.InfoLog("Setting pad number #{0} to value {1}", number, value);
-             
-            pin = pinstate(value);
-            
-            // var currentValue = State[number];  
+            this.InfoLog("Setting pad number #{0} to value {1}", number, value);  
            switch(number) {
             	case 0:
               	if(EN_S[0]) {
@@ -622,19 +613,11 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
 
           private void OnPinStateChanged(int number, bool current)
         {    
-            Connections[number].Set(pin);
-        }
-
-        public bool pinstate(bool value){
-            if(value)
-            return true;
-            else 
-            return false;
+            Connections[number].Set(current);
         }
 
            private uint selection(IOMode value)
-            {
-                
+            { 
                 switch((IOMode)value)
                 {
                 case IOMode.MainMode:               
@@ -656,7 +639,7 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
             }
         private void PrepareRegisters()
         {          
-                Registers.pad_csr.Define(this)
+            Registers.pad_csr.Define(this)
                // .WithTaggedFlag("STATUS",0)
                 .WithValueField(0, 31,FieldMode.Read|FieldMode.Write , name: "PADKEY",writeCallback: ( _, value) => {
                   if (value==PadKeyUnlockValue) {
@@ -678,11 +661,8 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                 }
                   )
                   .WithTaggedFlag("STATUS",31)
-                ; 
-                
-               Registers.std_pu_PAD_GPIO_A_0_ctl.Define(this)
-
-                
+            ;     
+            Registers.std_pu_PAD_GPIO_A_0_ctl.Define(this)      
                 .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN[0]=value)
                 .WithTag("DS", 1, 2)
                 .WithReservedBits(3, 2)
@@ -690,16 +670,12 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                 .WithTaggedFlag("PUD", 6)
                 .WithEnumField<DoubleWordRegister, IOMode>(7, 2,               
                 writeCallback: (_, value) =>  {
-
-                    MUX[0]=selection((IOMode)value);
-                    
+                    MUX[0]=selection((IOMode)value);     
                     },  
                 name: "FUNCMAX")
-                .WithReservedBits(9, 23) 
-                 
-                ;
-                
-                Registers.std_pu_PAD_GPIO_A_1_ctl.Define(this)
+                .WithReservedBits(9, 23)    
+            ;    
+            Registers.std_pu_PAD_GPIO_A_1_ctl.Define(this)
                 .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN[1]=value)
                 .WithTag("DS", 1, 2)
                 .WithReservedBits(3, 2)
@@ -710,11 +686,9 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                     MUX[1]=selection((IOMode)value);
                     },
                 name: "FUNCMAX")
-                .WithReservedBits(9, 23) 
-                
-            ;  
-
-                Registers.std_pu_PAD_GPIO_A_2_ctl.Define(this)
+                .WithReservedBits(9, 23)    
+            ; 
+            Registers.std_pu_PAD_GPIO_A_2_ctl.Define(this)
                 .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN[2]=value)
                 .WithTag("DS", 1, 2)
                 .WithReservedBits(3, 2)
@@ -725,10 +699,9 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                     MUX[2]=selection((IOMode)value);
                     },
                 name: "FUNCMAX")
-                .WithReservedBits(9, 23) 
-                
+                .WithReservedBits(9, 23)     
             ;  
-                Registers.std_pu_PAD_GPIO_A_3_ctl.Define(this)
+            Registers.std_pu_PAD_GPIO_A_3_ctl.Define(this)
                 .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN[3]=value)
                 .WithTag("DS", 1, 2)
                 .WithReservedBits(3, 2)
@@ -739,8 +712,7 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                     MUX[3]=selection((IOMode)value);
                     },
                 name: "FUNCMAX")
-                .WithReservedBits(9, 23) 
-                
+                .WithReservedBits(9, 23)    
             ; 
             Registers.std_pu_PAD_GPIO_A_4_ctl.Define(this)
                 .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN[4]=value)
@@ -753,8 +725,7 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                     MUX[4]=selection((IOMode)value);
                     },
                 name: "FUNCMAX")
-                .WithReservedBits(9, 23) 
-                
+                .WithReservedBits(9, 23)       
             ;
             Registers.std_pu_PAD_GPIO_A_5_ctl.Define(this)
                 .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN[5]=value)
@@ -767,8 +738,7 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                     MUX[5]=selection((IOMode)value);
                     },
                 name: "FUNCMAX")
-                .WithReservedBits(9, 23) 
-                
+                .WithReservedBits(9, 23)   
             ;
             Registers.std_pu_PAD_GPIO_A_6_ctl.Define(this)
                 .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN[6]=value)
@@ -781,8 +751,7 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                     MUX[6]=selection((IOMode)value);
                     },
                 name: "FUNCMAX")
-                .WithReservedBits(9, 23) 
-                
+                .WithReservedBits(9, 23)     
             ;
             Registers.std_pu_PAD_GPIO_A_7_ctl.Define(this)
                 .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN[7]=value)
@@ -795,8 +764,7 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                     MUX[7]=selection((IOMode)value);
                     },
                 name: "FUNCMAX")
-                .WithReservedBits(9, 23) 
-                
+                .WithReservedBits(9, 23)    
             ;
             Registers.std_pu_PAD_GPIO_A_8_ctl.Define(this)
                 .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN[8]=value)
@@ -809,8 +777,7 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                     MUX[8]=selection((IOMode)value);
                     },
                 name: "FUNCMAX")
-                .WithReservedBits(9, 23) 
-                
+                .WithReservedBits(9, 23)    
             ;
             Registers.std_pu_PAD_GPIO_A_9_ctl.Define(this)
                 .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN[9]=value)
@@ -823,10 +790,9 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                     MUX[9]=selection((IOMode)value);
                     },
                 name: "FUNCMAX")
-                .WithReservedBits(9, 23) 
-                
+                .WithReservedBits(9, 23)    
             ;
-             Registers.std_pu_PAD_GPIO_A_10_ctl.Define(this)
+            Registers.std_pu_PAD_GPIO_A_10_ctl.Define(this)
                 .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN[10]=value)
                 .WithTag("DS", 1, 2)
                 .WithReservedBits(3, 2)
@@ -835,11 +801,9 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                 .WithEnumField<DoubleWordRegister, IOMode>(7, 2, 
                 writeCallback: (_, value) =>  {
                     MUX[10]=selection((IOMode)value);
-                    },
-                
+                    }, 
                 name: "FUNCMAX")
-                .WithReservedBits(9, 23) 
-                
+                .WithReservedBits(9, 23)    
             ;  
             Registers.std_pu_PAD_GPIO_A_11_ctl.Define(this)
                 .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN[11]=value)
@@ -852,10 +816,8 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                     MUX[11]=selection((IOMode)value);
                     },
                 name: "FUNCMAX")
-                .WithReservedBits(9, 23) 
-                
+                .WithReservedBits(9, 23)    
             ;  
-
             Registers.std_pu_PAD_GPIO_A_12_ctl.Define(this)
                 .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN[12]=value)
                 .WithTag("DS", 1, 2)
@@ -868,10 +830,8 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                     },
                 
                 name: "FUNCMAX")
-                .WithReservedBits(9, 23) 
-                
+                .WithReservedBits(9, 23)     
             ;  
-
             Registers.std_pu_PAD_GPIO_A_13_ctl.Define(this)
                 .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN[13]=value)
                 .WithTag("DS", 1, 2)
@@ -883,8 +843,7 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                     MUX[13]=selection((IOMode)value);
                     },
                 name: "FUNCMAX")
-                .WithReservedBits(9, 23) 
-                
+                .WithReservedBits(9, 23)    
             ;
             Registers.std_pu_PAD_GPIO_A_14_ctl.Define(this)
                 .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN[14]=value)
@@ -897,8 +856,7 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                     MUX[14]=selection((IOMode)value);
                     },
                 name: "FUNCMAX")
-                .WithReservedBits(9, 23) 
-                
+                .WithReservedBits(9, 23)     
             ;
             Registers.std_pu_PAD_GPIO_A_15_ctl.Define(this)
                 .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN[15]=value)
@@ -911,18 +869,11 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                     MUX[15]=selection((IOMode)value);
                     },
                 name: "FUNCMAX")
-                .WithReservedBits(9, 23) 
-                
-            ;
-
-      
-              
+                .WithReservedBits(9, 23)    
+            ;              
         }
-
-        public bool pin;
-
+        
         private const int NumberOfGPIOs = 80;
-        private uint padKey;
         public const uint PadKeyUnlockValue = 0x2A6;
         public bool registerunlocked=false;
 
@@ -931,22 +882,13 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
         private uint[] MUX_S=new uint[16];
         private bool[] EN_S = new bool[16];
 
-
-
-         public enum IOMode
+        public enum IOMode
         {   MainMode = 0, 
             Fpga_pinMode = 1, 
             AlternativeMode = 2, 
             DebugMode = 3
         }
-        private enum ShadowRegisters
-        {
-          Register0,
-          Register1,
-          Register2,
-          Register3,
-          Register4,
-        }
+  
         private enum Registers
         {
             pad_csr = 0x1000,

--- a/src/Emulator/Peripherals/Peripherals/GPIOPort/Virgo_pad.cs
+++ b/src/Emulator/Peripherals/Peripherals/GPIOPort/Virgo_pad.cs
@@ -27,6 +27,7 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
             
          RegistersCollection = new DoubleWordRegisterCollection(this);
          PrepareRegisters();
+         //InternalRegisters();
         }
 
         public override void Reset()
@@ -41,18 +42,12 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
         {
             return RegistersCollection.Read(offset);
         }
-
+         
+        
         public void WriteDoubleWord(long offset, uint value)
         {  
-          if(offset >= (long)Registers.std_pu_PAD_GPIO_A_0_ctl && offset <= (long)Registers.std_pu_PAD_GPIO_A_15_ctl)
-            if(!registerunlocked)
-                {
-                    this.Log(LogLevel.Warning, "Tried to change pin configuration register which is locked. PADKEY value: {0:X}", padKey);
-                    this.InfoLog("registeunlocked {0}", registerunlocked);
-                    return;
-                }
-                this.InfoLog("pads unlocked");
-            RegistersCollection.Write(offset, value);
+          
+         RegistersCollection.Write(offset, value);
         }
         
         public override void OnGPIO(int number, bool value)
@@ -70,8 +65,8 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
             // var currentValue = State[number];  
            switch(number) {
             	case 0:
-              	if(EN_0) {
-                	switch(MUX_0) {
+              	if(EN_S[0]) {
+                	switch(MUX_S[0]) {
                   	case 1: 
                     	OnPinStateChanged(number+16, value);
                         break;
@@ -91,8 +86,8 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                 break;
                 
                 case 1:
-                	if(EN_1) {
-                  	switch(MUX_1) {
+                	if(EN_S[1]) {
+                  	switch(MUX_S[1]) {
                     case 1:
                         OnPinStateChanged(number+16, value);
                         break;
@@ -112,8 +107,8 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                 break;
 
                 case 2:
-                	if(EN_2) {
-                  	switch(MUX_2) {
+                	if(EN_S[2]) {
+                  	switch(MUX_S[2]) {
                     case 1:
                         break;
                     case 2:
@@ -130,8 +125,8 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                 break; 
 
                 case 3:
-                	if(EN_3) {
-                  	switch(MUX_3) {
+                	if(EN_S[3]) {
+                  	switch(MUX_S[3]) {
                     case 1:
                         break;
                     case 2:
@@ -148,8 +143,8 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                 break;
 
                 case 4:
-                	if(EN_4) {
-                  	switch(MUX_4) {
+                	if(EN_S[4]) {
+                  	switch(MUX_S[4]) {
                     case 1:
                         break;
                     case 2:
@@ -167,8 +162,8 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                 break;
 
                 case 5:
-                	if(EN_5) {
-                  	switch(MUX_5) {
+                	if(EN_S[5]) {
+                  	switch(MUX_S[5]) {
                     case 1:
                         break;
                     case 2:
@@ -186,8 +181,8 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                 break;
 
                 case 6:
-                	if(EN_6) {
-                  	switch(MUX_6) {
+                	if(EN_S[6]) {
+                  	switch(MUX_S[6]) {
                     case 1:
                         break;
                     case 2:
@@ -205,8 +200,8 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                 break;
 
                 case 7:
-                	if(EN_7) {
-                  	switch(MUX_7) {
+                	if(EN_S[7]) {
+                  	switch(MUX_S[7]) {
                     case 1:
                         break;
                     case 2:
@@ -224,8 +219,8 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                 break;
             
                 case 8:
-                	if(EN_8) {
-                  	switch(MUX_8) {
+                	if(EN_S[8]) {
+                  	switch(MUX_S[8]) {
                     case 1:
                         break;
                     case 2:
@@ -243,8 +238,8 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                 break;
                 
                 case 9:
-                	if(EN_9) {
-                  	switch(MUX_10) {
+                	if(EN_S[9]) {
+                  	switch(MUX_S[10]) {
                     case 1:
                         break;
                     case 2:
@@ -262,8 +257,8 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                 break;
 
                 case 10:
-                	if(EN_10) {
-                  	switch(MUX_10) {
+                	if(EN_S[10]) {
+                  	switch(MUX_S[10]) {
                     case 1:
                         OnPinStateChanged(number+16, value);
                         break;
@@ -282,8 +277,8 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                 break;
 
                 case 11:
-                	if(EN_11) {
-                  	switch(MUX_11) {
+                	if(EN_S[11]) {
+                  	switch(MUX_S[11]) {
                     case 1:
                         OnPinStateChanged(number+16, value);
                         break;
@@ -302,8 +297,8 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                 break;
 
                 case 12:
-                	if(EN_12) {
-                  	switch(MUX_12) {
+                	if(EN_S[12]) {
+                  	switch(MUX_S[12]) {
                     case 1:
                         OnPinStateChanged(number+16, value);
                         break;
@@ -322,8 +317,8 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                 break;
                 
                 case 13:
-                	if(EN_13) {
-                  	switch(MUX_13) {
+                	if(EN_S[13]) {
+                  	switch(MUX_S[13]) {
                     case 1:
                         OnPinStateChanged(number+16, value);
                         break;
@@ -342,8 +337,8 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                 break;
 
                 case 14:
-                	if(EN_14) {
-                  	switch(MUX_14) {
+                	if(EN_S[14]) {
+                  	switch(MUX_S[14]) {
                     case 1:
                         OnPinStateChanged(number+16, value);
                         break;
@@ -362,8 +357,8 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                 break;
 
                 case 15:
-                	if(EN_15) {
-                  	switch(MUX_15) {
+                	if(EN_S[15]) {
+                  	switch(MUX_S[15]) {
                     case 1:
                         OnPinStateChanged(number+16, value);
                         break;
@@ -382,241 +377,241 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                 break;
 
                 case 16:
-                	if(EN_0 && (MUX_0 == 1)) {
+                	if(EN_S[0] && (MUX_S[0] == 1)) {
                   	OnPinStateChanged(number-16, value);
                   }
                   break;
                 
                 case 17:
-                	if(EN_1 && (MUX_1 == 1)) {
+                	if(EN_S[1] && (MUX_S[1] == 1)) {
                   	OnPinStateChanged(number-16, value);
                   }
                   break;
 
                 case 26:
-                	if(EN_10 && (MUX_10 == 1)) {
+                	if(EN_S[10] && (MUX_S[10] == 1)) {
                   	OnPinStateChanged(number-16, value);
                   }
                   break;
 
                 case 27:
-                	if(EN_11 && (MUX_11 == 1)) {
+                	if(EN_S[11] && (MUX_S[11] == 1)) {
                   	OnPinStateChanged(number-16, value);
                   }
                   break;
                 
                 case 28:
-                	if(EN_12 && (MUX_12 == 1)) {
+                	if(EN_S[12] && (MUX_S[12] == 1)) {
                   	OnPinStateChanged(number-16, value);
                   }
                   break;
 
                 case 29:
-                	if(EN_13 && (MUX_13 == 1)) {
+                	if(EN_S[13] && (MUX_S[13] == 1)) {
                   	OnPinStateChanged(number-16, value);
                   }
                   break;
                 
                 case 30:
-                	if(EN_14 && (MUX_14 == 1)) {
+                	if(EN_S[14] && (MUX_S[14] == 1)) {
                   	OnPinStateChanged(number-16, value);
                   }
                   break;
                 
                 case 31:
-                	if(EN_15 && (MUX_15 == 1)) {
+                	if(EN_S[15] && (MUX_S[15] == 1)) {
                   	OnPinStateChanged(number-16, value);
                   }
                   break;
 
                 case 32:
-                	if(EN_0 && (MUX_0 == 2)) {
+                	if(EN_S[0] && (MUX_S[0] == 2)) {
                   	OnPinStateChanged(number-32, value);
                   }
                   break;
                 
                 case 33:
-                	if(EN_1 && (MUX_1 == 2)) {
+                	if(EN_S[1] && (MUX_S[1] == 2)) {
                   	OnPinStateChanged(number-32, value);
                   }
                   break;
 
                 case 34:
-                	if(EN_2 && (MUX_2 == 2)) {
+                	if(EN_S[2] && (MUX_S[2] == 2)) {
                   	OnPinStateChanged(number-32, value);
                   }
                   break;
                 
                 case 35:
-                	if(EN_3 && (MUX_3 == 2)) {
+                	if(EN_S[3] && (MUX_S[3] == 2)) {
                   	OnPinStateChanged(number-32, value);
                   }
                   break;
                 
                 case 36:
-                	if(EN_4 && (MUX_4 == 2)) {
+                	if(EN_S[4] && (MUX_S[4] == 2)) {
                   	OnPinStateChanged(number-32, value);
                   }
                   break;
 
                 case 37:
-                	if(EN_5 && (MUX_5 == 2)) {
+                	if(EN_S[5] && (MUX_S[5] == 2)) {
                   	OnPinStateChanged(number-32, value);
                   }
                   break;
             
                 case 38:
-                	if(EN_6 && (MUX_6 == 2)) {
+                	if(EN_S[6] && (MUX_S[6] == 2)) {
                   	OnPinStateChanged(number-32, value);
                   }
                   break;
                 
                 case 39:
-                	if(EN_7 && (MUX_7 == 2)) {
+                	if(EN_S[7] && (MUX_S[7] == 2)) {
                   	OnPinStateChanged(number-32, value);
                   }
                   break;
                 
                 case 40:
-                	if(EN_8 && (MUX_8 == 2)) {
+                	if(EN_S[8] && (MUX_S[8] == 2)) {
                   	OnPinStateChanged(number-32, value);
                   }
                   break;
                 
                 case 41:
-                	if(EN_9 && (MUX_9 == 2)) {
+                	if(EN_S[9] && (MUX_S[9] == 2)) {
                   	OnPinStateChanged(number-32, value);
                   }
                   break;
                 
                 case 42:
-                	if(EN_10 && (MUX_10 == 2)) {
+                	if(EN_S[10] && (MUX_S[10] == 2)) {
                   	OnPinStateChanged(number-32, value);
                   }
                   break;
 
                 case 43:
-                	if(EN_11 && (MUX_11 == 2)) {
+                	if(EN_S[11] && (MUX_S[11] == 2)) {
                   	OnPinStateChanged(number-32, value);
                   }
                   break;
 
                 case 44:
-                	if(EN_12 && (MUX_12 == 2)) {
+                	if(EN_S[12] && (MUX_S[12] == 2)) {
                   	OnPinStateChanged(number-32, value);
                   }
                   break;
 
                 case 45:
-                	if(EN_13 && (MUX_13 == 2)) {
+                	if(EN_S[13] && (MUX_S[13] == 2)) {
                   	OnPinStateChanged(number-32, value);
                   }
                   break;
 
                 case 46:
-                	if(EN_14 && (MUX_14 == 2)) {
+                	if(EN_S[14] && (MUX_S[14] == 2)) {
                   	OnPinStateChanged(number-32, value);
                   }
                   break;
 
                 case 47:
-                	if(EN_15 && (MUX_15 == 2)) {
+                	if(EN_S[15] && (MUX_S[15] == 2)) {
                   	OnPinStateChanged(number-32, value);
                   }
                   break;
                 
                 case 48:
-                	if(EN_0 && (MUX_0 == 3)) {
+                	if(EN_S[0] && (MUX_S[0] == 3)) {
                   	OnPinStateChanged(number-48, value);
                   }
                   break;
 
                 case 49:
-                	if(EN_1 && (MUX_1 == 3)) {
+                	if(EN_S[1] && (MUX_S[1] == 3)) {
                   	OnPinStateChanged(number-48, value);
                   }
                   break;
                 
                 case 58:
-                	if(EN_10 && (MUX_10 == 3)) {
+                	if(EN_S[10] && (MUX_S[10] == 3)) {
                   	OnPinStateChanged(number-48, value);
                   }
                   break;
                 
                 case 59:
-                	if(EN_11 && (MUX_11 == 3)) {
+                	if(EN_S[11] && (MUX_S[11] == 3)) {
                   	OnPinStateChanged(number-48, value);
                   }
                   break;
                 
                 case 60:
-                	if(EN_12 && (MUX_12 == 3)) {
+                	if(EN_S[12] && (MUX_S[12] == 3)) {
                   	OnPinStateChanged(number-48, value);
                   }
                   break;
 
                 case 61:
-                	if(EN_13 && (MUX_13 == 3)) {
+                	if(EN_S[13] && (MUX_S[13] == 3)) {
                   	OnPinStateChanged(number-48, value);
                   }
                   break;
 
                 case 62:
-                	if(EN_14 && (MUX_14 == 3)) {
+                	if(EN_S[14] && (MUX_S[14] == 3)) {
                   	OnPinStateChanged(number-48, value);
                   }
                   break;
 
                 case 63:
-                	if(EN_15 && (MUX_15 == 3)) {
+                	if(EN_S[15] && (MUX_S[15] == 3)) {
                   	OnPinStateChanged(number-48, value);
                   }
                   break;
 
                 case 64:
-                	if(EN_0 && (MUX_0 == 4)) {
+                	if(EN_S[0] && (MUX_S[0] == 4)) {
                   	OnPinStateChanged(number-64, value);
                   }
                   break;
                 
                 case 65:
-                	if(EN_1 && (MUX_1 == 4)) {
+                	if(EN_S[0] && (MUX_S[1] == 4)) {
                   	OnPinStateChanged(number-64, value);
                   }
                   break;
                  
                 case 68:
-                	if(EN_4 && (MUX_4 == 4)) {
+                	if(EN_S[4] && (MUX_S[4] == 4)) {
                   	OnPinStateChanged(number-64, value);
                   }
                   break;
 
                 case 69:
-                	if(EN_5 && (MUX_5 == 4)) {
+                	if(EN_S[5] && (MUX_S[5] == 4)) {
                   	OnPinStateChanged(number-64, value);
                   }
                   break;
                 
                 case 70:
-                	if(EN_6 && (MUX_6 == 4)) {
+                	if(EN_S[6] && (MUX_S[6] == 4)) {
                   	OnPinStateChanged(number-64, value);
                   }
                   break;
 
                 case 71:
-                	if(EN_7 && (MUX_7 == 4)) {
+                	if(EN_S[7] && (MUX_S[7] == 4)) {
                   	OnPinStateChanged(number-64, value);
                   }
                   break;
                 
                 case 72:
-                	if(EN_8 && (MUX_8 == 4)) {
+                	if(EN_S[8] && (MUX_S[8] == 4)) {
                   	OnPinStateChanged(number-64, value);
                   }
                   break;
 
                 case 73:
-                	if(EN_9 && (MUX_9 == 4)) {
+                	if(EN_S[9] && (MUX_S[9] == 4)) {
                   	OnPinStateChanged(number-64, value);
                   }
                   break;
@@ -660,20 +655,35 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                 }
             }
         private void PrepareRegisters()
-        {
+        {          
                 Registers.pad_csr.Define(this)
                // .WithTaggedFlag("STATUS",0)
-                 //.WithReservedBits(0, 1)
                 .WithValueField(0, 31,FieldMode.Read|FieldMode.Write , name: "PADKEY",writeCallback: ( _, value) => {
-                  if (value==PadKeyUnlockValue)
-                   registerunlocked=true;
-                    this.InfoLog("registeunlocked in register {0}", registerunlocked); }
+                  if (value==PadKeyUnlockValue) {
+                  registerunlocked=true;
+                   {  
+                       for (var i=0; i<=15; i++ )
+                       {
+                           EN_S[i]=EN[i];
+                       }
+                        for (var i=0; i<=15; i++ )
+                       {
+                           MUX_S[i]=MUX[i];
+                       }
+                   
+                   }
+                  
+                  }
+                   this.InfoLog(" register unlock{0}", registerunlocked);
+                }
                   )
                   .WithTaggedFlag("STATUS",31)
                 ; 
                 
-                Registers.std_pu_PAD_GPIO_A_0_ctl.Define(this)
-                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN_0=value)
+               Registers.std_pu_PAD_GPIO_A_0_ctl.Define(this)
+
+                
+                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN[0]=value)
                 .WithTag("DS", 1, 2)
                 .WithReservedBits(3, 2)
                 .WithTaggedFlag("PUE", 5)
@@ -681,22 +691,23 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                 .WithEnumField<DoubleWordRegister, IOMode>(7, 2,               
                 writeCallback: (_, value) =>  {
 
-                    MUX_0=selection((IOMode)value);
+                    MUX[0]=selection((IOMode)value);
+                    
                     },  
                 name: "FUNCMAX")
                 .WithReservedBits(9, 23) 
-
+                 
                 ;
                 
                 Registers.std_pu_PAD_GPIO_A_1_ctl.Define(this)
-                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN_1=value)
+                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN[1]=value)
                 .WithTag("DS", 1, 2)
                 .WithReservedBits(3, 2)
                 .WithTaggedFlag("PUE", 5)
                 .WithTaggedFlag("PUD", 6)
                 .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
                 writeCallback: (_, value) =>  {
-                    MUX_1=selection((IOMode)value);
+                    MUX[1]=selection((IOMode)value);
                     },
                 name: "FUNCMAX")
                 .WithReservedBits(9, 23) 
@@ -704,126 +715,126 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
             ;  
 
                 Registers.std_pu_PAD_GPIO_A_2_ctl.Define(this)
-                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN_2=value)
+                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN[2]=value)
                 .WithTag("DS", 1, 2)
                 .WithReservedBits(3, 2)
                 .WithTaggedFlag("PUE", 5)
                 .WithTaggedFlag("PUD", 6)
                 .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
                 writeCallback: (_, value) =>  {
-                    MUX_2=selection((IOMode)value);
+                    MUX[2]=selection((IOMode)value);
                     },
                 name: "FUNCMAX")
                 .WithReservedBits(9, 23) 
                 
             ;  
                 Registers.std_pu_PAD_GPIO_A_3_ctl.Define(this)
-                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN_3=value)
+                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN[3]=value)
                 .WithTag("DS", 1, 2)
                 .WithReservedBits(3, 2)
                 .WithTaggedFlag("PUE", 5)
                 .WithTaggedFlag("PUD", 6)
                 .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
                 writeCallback: (_, value) =>  {
-                    MUX_3=selection((IOMode)value);
+                    MUX[3]=selection((IOMode)value);
                     },
                 name: "FUNCMAX")
                 .WithReservedBits(9, 23) 
                 
             ; 
             Registers.std_pu_PAD_GPIO_A_4_ctl.Define(this)
-                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN_4=value)
+                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN[4]=value)
                 .WithTag("DS", 1, 2)
                 .WithReservedBits(3, 2)
                 .WithTaggedFlag("PUE", 5)
                 .WithTaggedFlag("PUD", 6)
                 .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
                 writeCallback: (_, value) =>  {
-                    MUX_4=selection((IOMode)value);
+                    MUX[4]=selection((IOMode)value);
                     },
                 name: "FUNCMAX")
                 .WithReservedBits(9, 23) 
                 
             ;
             Registers.std_pu_PAD_GPIO_A_5_ctl.Define(this)
-                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN_5=value)
+                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN[5]=value)
                 .WithTag("DS", 1, 2)
                 .WithReservedBits(3, 2)
                 .WithTaggedFlag("PUE", 5)
                 .WithTaggedFlag("PUD", 6)
                 .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
                 writeCallback: (_, value) =>  {
-                    MUX_5=selection((IOMode)value);
+                    MUX[5]=selection((IOMode)value);
                     },
                 name: "FUNCMAX")
                 .WithReservedBits(9, 23) 
                 
             ;
             Registers.std_pu_PAD_GPIO_A_6_ctl.Define(this)
-                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN_6=value)
+                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN[6]=value)
                 .WithTag("DS", 1, 2)
                 .WithReservedBits(3, 2)
                 .WithTaggedFlag("PUE", 5)
                 .WithTaggedFlag("PUD", 6)
                 .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
                 writeCallback: (_, value) =>  {
-                    MUX_6=selection((IOMode)value);
+                    MUX[6]=selection((IOMode)value);
                     },
                 name: "FUNCMAX")
                 .WithReservedBits(9, 23) 
                 
             ;
             Registers.std_pu_PAD_GPIO_A_7_ctl.Define(this)
-                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN_7=value)
+                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN[7]=value)
                 .WithTag("DS", 1, 2)
                 .WithReservedBits(3, 2)
                 .WithTaggedFlag("PUE", 5)
                 .WithTaggedFlag("PUD", 6)
                 .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
                 writeCallback: (_, value) =>  {
-                    MUX_7=selection((IOMode)value);
+                    MUX[7]=selection((IOMode)value);
                     },
                 name: "FUNCMAX")
                 .WithReservedBits(9, 23) 
                 
             ;
             Registers.std_pu_PAD_GPIO_A_8_ctl.Define(this)
-                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN_8=value)
+                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN[8]=value)
                 .WithTag("DS", 1, 2)
                 .WithReservedBits(3, 2)
                 .WithTaggedFlag("PUE", 5)
                 .WithTaggedFlag("PUD", 6)
                 .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
                 writeCallback: (_, value) =>  {
-                    MUX_8=selection((IOMode)value);
+                    MUX[8]=selection((IOMode)value);
                     },
                 name: "FUNCMAX")
                 .WithReservedBits(9, 23) 
                 
             ;
             Registers.std_pu_PAD_GPIO_A_9_ctl.Define(this)
-                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN_9=value)
+                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN[9]=value)
                 .WithTag("DS", 1, 2)
                 .WithReservedBits(3, 2)
                 .WithTaggedFlag("PUE", 5)
                 .WithTaggedFlag("PUD", 6)
                 .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
                 writeCallback: (_, value) =>  {
-                    MUX_9=selection((IOMode)value);
+                    MUX[9]=selection((IOMode)value);
                     },
                 name: "FUNCMAX")
                 .WithReservedBits(9, 23) 
                 
             ;
              Registers.std_pu_PAD_GPIO_A_10_ctl.Define(this)
-                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN_10=value)
+                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN[10]=value)
                 .WithTag("DS", 1, 2)
                 .WithReservedBits(3, 2)
                 .WithTaggedFlag("PUE", 5)
                 .WithTaggedFlag("PUD", 6)
                 .WithEnumField<DoubleWordRegister, IOMode>(7, 2, 
                 writeCallback: (_, value) =>  {
-                    MUX_10=selection((IOMode)value);
+                    MUX[10]=selection((IOMode)value);
                     },
                 
                 name: "FUNCMAX")
@@ -831,14 +842,14 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                 
             ;  
             Registers.std_pu_PAD_GPIO_A_11_ctl.Define(this)
-                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN_11=value)
+                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN[11]=value)
                 .WithTag("DS", 1, 2)
                 .WithReservedBits(3, 2)
                 .WithTaggedFlag("PUE", 5)
                 .WithTaggedFlag("PUD", 6)
                 .WithEnumField<DoubleWordRegister, IOMode>(7, 2,  
                 writeCallback: (_, value) =>  {
-                    MUX_11=selection((IOMode)value);
+                    MUX[11]=selection((IOMode)value);
                     },
                 name: "FUNCMAX")
                 .WithReservedBits(9, 23) 
@@ -846,14 +857,14 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
             ;  
 
             Registers.std_pu_PAD_GPIO_A_12_ctl.Define(this)
-                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN_12=value)
+                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN[12]=value)
                 .WithTag("DS", 1, 2)
                 .WithReservedBits(3, 2)
                 .WithTaggedFlag("PUE", 5)
                 .WithTaggedFlag("PUD", 6)
                 .WithEnumField<DoubleWordRegister, IOMode>(7, 2,  
                 writeCallback: (_, value) =>  {
-                MUX_12=selection((IOMode)value);
+                MUX[12]=selection((IOMode)value);
                     },
                 
                 name: "FUNCMAX")
@@ -862,57 +873,65 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
             ;  
 
             Registers.std_pu_PAD_GPIO_A_13_ctl.Define(this)
-                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN_13=value)
+                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN[13]=value)
                 .WithTag("DS", 1, 2)
                 .WithReservedBits(3, 2)
                 .WithTaggedFlag("PUE", 5)
                 .WithTaggedFlag("PUD", 6)
                 .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
                 writeCallback: (_, value) =>  {
-                    MUX_13=selection((IOMode)value);
+                    MUX[13]=selection((IOMode)value);
                     },
                 name: "FUNCMAX")
                 .WithReservedBits(9, 23) 
                 
             ;
             Registers.std_pu_PAD_GPIO_A_14_ctl.Define(this)
-                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN_14=value)
+                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN[14]=value)
                 .WithTag("DS", 1, 2)
                 .WithReservedBits(3, 2)
                 .WithTaggedFlag("PUE", 5)
                 .WithTaggedFlag("PUD", 6)
                 .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
                 writeCallback: (_, value) =>  {
-                    MUX_14=selection((IOMode)value);
+                    MUX[14]=selection((IOMode)value);
                     },
                 name: "FUNCMAX")
                 .WithReservedBits(9, 23) 
                 
             ;
             Registers.std_pu_PAD_GPIO_A_15_ctl.Define(this)
-                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN_15=value)
+                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN[15]=value)
                 .WithTag("DS", 1, 2)
                 .WithReservedBits(3, 2)
                 .WithTaggedFlag("PUE", 5)
                 .WithTaggedFlag("PUD", 6)
                 .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
                 writeCallback: (_, value) =>  {
-                    MUX_15=selection((IOMode)value);
+                    MUX[15]=selection((IOMode)value);
                     },
                 name: "FUNCMAX")
                 .WithReservedBits(9, 23) 
                 
             ;
 
+      
+              
         }
-       
+
         public bool pin;
-        private uint MUX_0,MUX_1,MUX_2, MUX_3, MUX_4, MUX_5, MUX_6, MUX_7 , MUX_8 , MUX_9 ,MUX_10,MUX_11, MUX_12,MUX_13,MUX_14,MUX_15;
-        private bool EN_0,EN_1,EN_2,EN_3,EN_4,EN_5,EN_6,EN_7,EN_8,EN_9,EN_10,EN_11,EN_12,EN_13,EN_14,EN_15;
+
         private const int NumberOfGPIOs = 80;
         private uint padKey;
         public const uint PadKeyUnlockValue = 0x2A6;
         public bool registerunlocked=false;
+
+        private uint[] MUX=new uint[16];
+        private bool[] EN = new bool[16];
+        private uint[] MUX_S=new uint[16];
+        private bool[] EN_S = new bool[16];
+
+
 
          public enum IOMode
         {   MainMode = 0, 
@@ -920,7 +939,14 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
             AlternativeMode = 2, 
             DebugMode = 3
         }
- 
+        private enum ShadowRegisters
+        {
+          Register0,
+          Register1,
+          Register2,
+          Register3,
+          Register4,
+        }
         private enum Registers
         {
             pad_csr = 0x1000,

--- a/src/Emulator/Peripherals/Peripherals/Miscellaneous/RS_SystemControlUnit.cs
+++ b/src/Emulator/Peripherals/Peripherals/Miscellaneous/RS_SystemControlUnit.cs
@@ -147,7 +147,7 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
             Registers.PufccControl.Define(this, 0x0)
                 .WithFlag(0, name:"pucc_rng_fre_out")
                 .WithFlag(1, name:"pucc_rng_fre_sel")
-                .WithFlag(1, name:"pucc_rng_fre_en"); // P2
+                .WithFlag(2, name:"pucc_rng_fre_en"); // P2
             Registers.FpgaPll.Define(this, 0x0); // P3
             var wdtPauseReg = Registers.WdtPause.Define(this, 0x0)
                 .WithFlag(0, changeCallback: (oldVal, newVal) =>

--- a/src/Emulator/Peripherals/Peripherals/Miscellaneous/Virgo_pad.cs
+++ b/src/Emulator/Peripherals/Peripherals/Miscellaneous/Virgo_pad.cs
@@ -15,10 +15,9 @@ using Antmicro.Renode.Core;
 using Antmicro.Renode.Core.Structure.Registers;
 using Antmicro.Renode.Peripherals.Bus;
 using Antmicro.Renode.Utilities;
-using static Antmicro.Renode.Peripherals.GPIOPort.ATCGPIO100;
-//using Antmicro.Renode.Peripherals.GPIOPort;
+using Antmicro.Renode.Peripherals.GPIOPort;
 
-namespace Antmicro.Renode.Peripherals.GPIOPort
+namespace Antmicro.Renode.Peripherals.Miscellaneous
 {
     public class Virgo_pad : BaseGPIOPort, IProvidesRegisterCollection<DoubleWordRegisterCollection>, IDoubleWordPeripheral, IKnownSize,IGPIOReceiver
     {
@@ -621,16 +620,16 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                 switch((IOMode)value)
                 {
                 case IOMode.MainMode:               
-                this.InfoLog("mode 1");    
+                this.InfoLog("Select {0}", value);    
                 return 1;            
                 case IOMode.Fpga_pinMode:             
-                this.InfoLog("mode 2");
+                this.InfoLog("Select {0}",value);
                 return 2; 
                 case IOMode.AlternativeMode:
-                this.InfoLog("mode 3"); 
+                this.InfoLog("Select {0}",value); 
                 return 3;
                 case IOMode.DebugMode:
-                this.InfoLog("mode 4"); 
+                this.InfoLog("Select {0}",value); 
                 return 4;
                 default:
                     this.InfoLog(" Non existitng possible value written as selection lines.");
@@ -657,9 +656,8 @@ namespace Antmicro.Renode.Peripherals.GPIOPort
                    }
                   
                   }
-                   this.InfoLog(" register unlock{0}", registerunlocked);
-                }
-                  )
+                   this.InfoLog(" Pad key set to {0}", registerunlocked);
+                })
                   .WithTaggedFlag("STATUS",31)
             ;     
             Registers.std_pu_PAD_GPIO_A_0_ctl.Define(this)      

--- a/src/Emulator/Peripherals/Peripherals/Miscellaneous/Virgo_pad.cs
+++ b/src/Emulator/Peripherals/Peripherals/Miscellaneous/Virgo_pad.cs
@@ -58,16 +58,16 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
               	if(EN_S[0]) {
                 	switch(MUX_S[0]) {
                   	case 1: 
-                    	OnPinStateChanged(number+16, value);
+                    	OnPinStateChanged(number+GPIOPinsIndex, value);
                         break;
                     case 2:
-                    	OnPinStateChanged(number+32, value);
+                    	OnPinStateChanged(number+FPGAPinsIndex, value);
                         break;
                     case 3:
-                        OnPinStateChanged(number+48, value);
+                        OnPinStateChanged(number+AltPinsIndex, value);
                         break;
                     case 4:
-                        OnPinStateChanged(number+64, value);
+                        OnPinStateChanged(number+DebugPinsIndex, value);
                         break;
                     default:
                     	break;
@@ -79,16 +79,16 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                 	if(EN_S[1]) {
                   	switch(MUX_S[1]) {
                     case 1:
-                        OnPinStateChanged(number+16, value);
+                        OnPinStateChanged(number+GPIOPinsIndex, value);
                         break;
                     case 2:
-                      	OnPinStateChanged(number+32, value);
+                      	OnPinStateChanged(number+FPGAPinsIndex, value);
                         break;
                     case 3:
-                        OnPinStateChanged(number+48, value);
+                        OnPinStateChanged(number+AltPinsIndex, value);
                         break;
                     case 4:
-                        OnPinStateChanged(number+64, value);
+                        OnPinStateChanged(number+DebugPinsIndex, value);
                         break;
                     default:
                       	break;
@@ -102,7 +102,7 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                     case 1:
                         break;
                     case 2:
-                      	OnPinStateChanged(number+32, value);
+                      	OnPinStateChanged(number+FPGAPinsIndex, value);
                         break;
                     case 3:
                         break;
@@ -120,7 +120,7 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                     case 1:
                         break;
                     case 2:
-                      	OnPinStateChanged(number+32, value);
+                      	OnPinStateChanged(number+FPGAPinsIndex, value);
                         break;
                     case 3:
                         break;
@@ -138,12 +138,12 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                     case 1:
                         break;
                     case 2:
-                      	OnPinStateChanged(number+32, value);
+                      	OnPinStateChanged(number+FPGAPinsIndex, value);
                         break;
                     case 3:
                         break;
                     case 4:
-                        OnPinStateChanged(number+64, value);
+                        OnPinStateChanged(number+DebugPinsIndex, value);
                         break;
                     default:
                       	break;
@@ -157,12 +157,12 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                     case 1:
                         break;
                     case 2:
-                      	OnPinStateChanged(number+32, value);
+                      	OnPinStateChanged(number+FPGAPinsIndex, value);
                         break;
                     case 3:
                         break;
                     case 4:
-                        OnPinStateChanged(number+64, value);
+                        OnPinStateChanged(number+DebugPinsIndex, value);
                         break;
                     default:
                       	break;
@@ -176,12 +176,12 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                     case 1:
                         break;
                     case 2:
-                      	OnPinStateChanged(number+32, value);
+                      	OnPinStateChanged(number+FPGAPinsIndex, value);
                         break;
                     case 3:
                         break;
                     case 4:
-                        OnPinStateChanged(number+64, value);
+                        OnPinStateChanged(number+DebugPinsIndex, value);
                         break;
                     default:
                       	break;
@@ -195,12 +195,12 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                     case 1:
                         break;
                     case 2:
-                      	OnPinStateChanged(number+32, value);
+                      	OnPinStateChanged(number+FPGAPinsIndex, value);
                         break;
                     case 3:
                         break;
                     case 4:
-                        OnPinStateChanged(number+64, value);
+                        OnPinStateChanged(number+DebugPinsIndex, value);
                         break;
                     default:
                       	break;
@@ -214,12 +214,12 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                     case 1:
                         break;
                     case 2:
-                      	OnPinStateChanged(number+32, value);
+                      	OnPinStateChanged(number+FPGAPinsIndex, value);
                         break;
                     case 3:
                         break;
                     case 4:
-                        OnPinStateChanged(number+64, value);
+                        OnPinStateChanged(number+DebugPinsIndex, value);
                         break;
                     default:
                       	break;
@@ -233,12 +233,12 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                     case 1:
                         break;
                     case 2:
-                      	OnPinStateChanged(number+32 , value);
+                      	OnPinStateChanged(number+FPGAPinsIndex , value);
                         break;
                     case 3:
                         break;
                     case 4:
-                        OnPinStateChanged(number+64, value);
+                        OnPinStateChanged(number+DebugPinsIndex, value);
                         break;
                     default:
                       	break;
@@ -250,13 +250,13 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                 	if(EN_S[10]) {
                   	switch(MUX_S[10]) {
                     case 1:
-                        OnPinStateChanged(number+16, value);
+                        OnPinStateChanged(number+GPIOPinsIndex, value);
                         break;
                     case 2:
-                      	OnPinStateChanged(number+32, value);
+                      	OnPinStateChanged(number+FPGAPinsIndex, value);
                         break;
                     case 3:
-                        OnPinStateChanged(number+48, value);
+                        OnPinStateChanged(number+AltPinsIndex, value);
                         break;
                     case 4:
                         break;
@@ -270,13 +270,13 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                 	if(EN_S[11]) {
                   	switch(MUX_S[11]) {
                     case 1:
-                        OnPinStateChanged(number+16, value);
+                        OnPinStateChanged(number+GPIOPinsIndex, value);
                         break;
                     case 2:
-                      	OnPinStateChanged(number+32, value);
+                      	OnPinStateChanged(number+FPGAPinsIndex, value);
                         break;
                     case 3:
-                        OnPinStateChanged(number+48, value);
+                        OnPinStateChanged(number+AltPinsIndex, value);
                         break;
                     case 4:
                         break;
@@ -290,13 +290,13 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                 	if(EN_S[12]) {
                   	switch(MUX_S[12]) {
                     case 1:
-                        OnPinStateChanged(number+16, value);
+                        OnPinStateChanged(number+GPIOPinsIndex, value);
                         break;
                     case 2:
-                      	OnPinStateChanged(number+32, value);
+                      	OnPinStateChanged(number+FPGAPinsIndex, value);
                         break;
                     case 3:
-                        OnPinStateChanged(number+48, value);
+                        OnPinStateChanged(number+AltPinsIndex, value);
                         break;
                     case 4:
                         break;
@@ -310,13 +310,13 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                 	if(EN_S[13]) {
                   	switch(MUX_S[13]) {
                     case 1:
-                        OnPinStateChanged(number+16, value);
+                        OnPinStateChanged(number+GPIOPinsIndex, value);
                         break;
                     case 2:
-                      	OnPinStateChanged(number+32, value);
+                      	OnPinStateChanged(number+FPGAPinsIndex, value);
                         break;
                     case 3:
-                        OnPinStateChanged(number+48, value);
+                        OnPinStateChanged(number+AltPinsIndex, value);
                         break;
                     case 4:
                         break;
@@ -330,13 +330,13 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                 	if(EN_S[14]) {
                   	switch(MUX_S[14]) {
                     case 1:
-                        OnPinStateChanged(number+16, value);
+                        OnPinStateChanged(number+GPIOPinsIndex, value);
                         break;
                     case 2:
-                      	OnPinStateChanged(number+32, value);
+                      	OnPinStateChanged(number+FPGAPinsIndex, value);
                         break;
                     case 3:
-                        OnPinStateChanged(number+48, value);
+                        OnPinStateChanged(number+AltPinsIndex, value);
                         break;
                     case 4:
                         break;
@@ -350,13 +350,13 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                 	if(EN_S[15]) {
                   	switch(MUX_S[15]) {
                     case 1:
-                        OnPinStateChanged(number+16, value);
+                        OnPinStateChanged(number+GPIOPinsIndex, value);
                         break;
                     case 2:
-                      	OnPinStateChanged(number+32, value);
+                      	OnPinStateChanged(number+FPGAPinsIndex, value);
                         break;
                     case 3:
-                        OnPinStateChanged(number+48, value);
+                        OnPinStateChanged(number+AltPinsIndex, value);
                         break;
                     case 4:
                         break;
@@ -368,241 +368,241 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
 
                 case 16:
                 	if(EN_S[0] && (MUX_S[0] == 1)) {
-                  	OnPinStateChanged(number-16, value);
+                  	OnPinStateChanged(number-GPIOPinsIndex, value);
                   }
                   break;
                 
                 case 17:
                 	if(EN_S[1] && (MUX_S[1] == 1)) {
-                  	OnPinStateChanged(number-16, value);
+                  	OnPinStateChanged(number-GPIOPinsIndex, value);
                   }
                   break;
 
                 case 26:
                 	if(EN_S[10] && (MUX_S[10] == 1)) {
-                  	OnPinStateChanged(number-16, value);
+                  	OnPinStateChanged(number-GPIOPinsIndex, value);
                   }
                   break;
 
                 case 27:
                 	if(EN_S[11] && (MUX_S[11] == 1)) {
-                  	OnPinStateChanged(number-16, value);
+                  	OnPinStateChanged(number-GPIOPinsIndex, value);
                   }
                   break;
                 
                 case 28:
                 	if(EN_S[12] && (MUX_S[12] == 1)) {
-                  	OnPinStateChanged(number-16, value);
+                  	OnPinStateChanged(number-GPIOPinsIndex, value);
                   }
                   break;
 
                 case 29:
                 	if(EN_S[13] && (MUX_S[13] == 1)) {
-                  	OnPinStateChanged(number-16, value);
+                  	OnPinStateChanged(number-GPIOPinsIndex, value);
                   }
                   break;
                 
                 case 30:
                 	if(EN_S[14] && (MUX_S[14] == 1)) {
-                  	OnPinStateChanged(number-16, value);
+                  	OnPinStateChanged(number-GPIOPinsIndex, value);
                   }
                   break;
                 
                 case 31:
                 	if(EN_S[15] && (MUX_S[15] == 1)) {
-                  	OnPinStateChanged(number-16, value);
+                  	OnPinStateChanged(number-GPIOPinsIndex, value);
                   }
                   break;
 
                 case 32:
                 	if(EN_S[0] && (MUX_S[0] == 2)) {
-                  	OnPinStateChanged(number-32, value);
+                  	OnPinStateChanged(number-FPGAPinsIndex, value);
                   }
                   break;
                 
                 case 33:
                 	if(EN_S[1] && (MUX_S[1] == 2)) {
-                  	OnPinStateChanged(number-32, value);
+                  	OnPinStateChanged(number-FPGAPinsIndex, value);
                   }
                   break;
 
                 case 34:
                 	if(EN_S[2] && (MUX_S[2] == 2)) {
-                  	OnPinStateChanged(number-32, value);
+                  	OnPinStateChanged(number-FPGAPinsIndex, value);
                   }
                   break;
                 
                 case 35:
                 	if(EN_S[3] && (MUX_S[3] == 2)) {
-                  	OnPinStateChanged(number-32, value);
+                  	OnPinStateChanged(number-FPGAPinsIndex, value);
                   }
                   break;
                 
                 case 36:
                 	if(EN_S[4] && (MUX_S[4] == 2)) {
-                  	OnPinStateChanged(number-32, value);
+                  	OnPinStateChanged(number-FPGAPinsIndex, value);
                   }
                   break;
 
                 case 37:
                 	if(EN_S[5] && (MUX_S[5] == 2)) {
-                  	OnPinStateChanged(number-32, value);
+                  	OnPinStateChanged(number-FPGAPinsIndex, value);
                   }
                   break;
             
                 case 38:
                 	if(EN_S[6] && (MUX_S[6] == 2)) {
-                  	OnPinStateChanged(number-32, value);
+                  	OnPinStateChanged(number-FPGAPinsIndex, value);
                   }
                   break;
                 
                 case 39:
                 	if(EN_S[7] && (MUX_S[7] == 2)) {
-                  	OnPinStateChanged(number-32, value);
+                  	OnPinStateChanged(number-FPGAPinsIndex, value);
                   }
                   break;
                 
                 case 40:
                 	if(EN_S[8] && (MUX_S[8] == 2)) {
-                  	OnPinStateChanged(number-32, value);
+                  	OnPinStateChanged(number-FPGAPinsIndex, value);
                   }
                   break;
                 
                 case 41:
                 	if(EN_S[9] && (MUX_S[9] == 2)) {
-                  	OnPinStateChanged(number-32, value);
+                  	OnPinStateChanged(number-FPGAPinsIndex, value);
                   }
                   break;
                 
                 case 42:
                 	if(EN_S[10] && (MUX_S[10] == 2)) {
-                  	OnPinStateChanged(number-32, value);
+                  	OnPinStateChanged(number-FPGAPinsIndex, value);
                   }
                   break;
 
                 case 43:
                 	if(EN_S[11] && (MUX_S[11] == 2)) {
-                  	OnPinStateChanged(number-32, value);
+                  	OnPinStateChanged(number-FPGAPinsIndex, value);
                   }
                   break;
 
                 case 44:
                 	if(EN_S[12] && (MUX_S[12] == 2)) {
-                  	OnPinStateChanged(number-32, value);
+                  	OnPinStateChanged(number-FPGAPinsIndex, value);
                   }
                   break;
 
                 case 45:
                 	if(EN_S[13] && (MUX_S[13] == 2)) {
-                  	OnPinStateChanged(number-32, value);
+                  	OnPinStateChanged(number-FPGAPinsIndex, value);
                   }
                   break;
 
                 case 46:
                 	if(EN_S[14] && (MUX_S[14] == 2)) {
-                  	OnPinStateChanged(number-32, value);
+                  	OnPinStateChanged(number-FPGAPinsIndex, value);
                   }
                   break;
 
                 case 47:
                 	if(EN_S[15] && (MUX_S[15] == 2)) {
-                  	OnPinStateChanged(number-32, value);
+                  	OnPinStateChanged(number-FPGAPinsIndex, value);
                   }
                   break;
                 
                 case 48:
                 	if(EN_S[0] && (MUX_S[0] == 3)) {
-                  	OnPinStateChanged(number-48, value);
+                  	OnPinStateChanged(number-AltPinsIndex, value);
                   }
                   break;
 
                 case 49:
                 	if(EN_S[1] && (MUX_S[1] == 3)) {
-                  	OnPinStateChanged(number-48, value);
+                  	OnPinStateChanged(number-AltPinsIndex, value);
                   }
                   break;
                 
                 case 58:
                 	if(EN_S[10] && (MUX_S[10] == 3)) {
-                  	OnPinStateChanged(number-48, value);
+                  	OnPinStateChanged(number-AltPinsIndex, value);
                   }
                   break;
                 
                 case 59:
                 	if(EN_S[11] && (MUX_S[11] == 3)) {
-                  	OnPinStateChanged(number-48, value);
+                  	OnPinStateChanged(number-AltPinsIndex, value);
                   }
                   break;
                 
                 case 60:
                 	if(EN_S[12] && (MUX_S[12] == 3)) {
-                  	OnPinStateChanged(number-48, value);
+                  	OnPinStateChanged(number-AltPinsIndex, value);
                   }
                   break;
 
                 case 61:
                 	if(EN_S[13] && (MUX_S[13] == 3)) {
-                  	OnPinStateChanged(number-48, value);
+                  	OnPinStateChanged(number-AltPinsIndex, value);
                   }
                   break;
 
                 case 62:
                 	if(EN_S[14] && (MUX_S[14] == 3)) {
-                  	OnPinStateChanged(number-48, value);
+                  	OnPinStateChanged(number-AltPinsIndex, value);
                   }
                   break;
 
                 case 63:
                 	if(EN_S[15] && (MUX_S[15] == 3)) {
-                  	OnPinStateChanged(number-48, value);
+                  	OnPinStateChanged(number-AltPinsIndex, value);
                   }
                   break;
 
                 case 64:
                 	if(EN_S[0] && (MUX_S[0] == 4)) {
-                  	OnPinStateChanged(number-64, value);
+                  	OnPinStateChanged(number-DebugPinsIndex, value);
                   }
                   break;
                 
                 case 65:
                 	if(EN_S[0] && (MUX_S[1] == 4)) {
-                  	OnPinStateChanged(number-64, value);
+                  	OnPinStateChanged(number-DebugPinsIndex, value);
                   }
                   break;
                  
                 case 68:
                 	if(EN_S[4] && (MUX_S[4] == 4)) {
-                  	OnPinStateChanged(number-64, value);
+                  	OnPinStateChanged(number-DebugPinsIndex, value);
                   }
                   break;
 
                 case 69:
                 	if(EN_S[5] && (MUX_S[5] == 4)) {
-                  	OnPinStateChanged(number-64, value);
+                  	OnPinStateChanged(number-DebugPinsIndex, value);
                   }
                   break;
                 
                 case 70:
                 	if(EN_S[6] && (MUX_S[6] == 4)) {
-                  	OnPinStateChanged(number-64, value);
+                  	OnPinStateChanged(number-DebugPinsIndex, value);
                   }
                   break;
 
                 case 71:
                 	if(EN_S[7] && (MUX_S[7] == 4)) {
-                  	OnPinStateChanged(number-64, value);
+                  	OnPinStateChanged(number-DebugPinsIndex, value);
                   }
                   break;
                 
                 case 72:
                 	if(EN_S[8] && (MUX_S[8] == 4)) {
-                  	OnPinStateChanged(number-64, value);
+                  	OnPinStateChanged(number-DebugPinsIndex, value);
                   }
                   break;
 
                 case 73:
                 	if(EN_S[9] && (MUX_S[9] == 4)) {
-                  	OnPinStateChanged(number-64, value);
+                  	OnPinStateChanged(number-DebugPinsIndex, value);
                   }
                   break;
 
@@ -636,29 +636,33 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                 return 0;
                 }
             }
+          
+          private void UpdateStatus(Registers reg , int i)
+          {
+            if (EN[i] != EN_S[i] || MUX[i] != MUX_S[i]) 
+                  status = false;       
+              
+          }
         private void PrepareRegisters()
         {          
             Registers.pad_csr.Define(this)
-               // .WithTaggedFlag("STATUS",0)
-                .WithValueField(0, 31,FieldMode.Read|FieldMode.Write , name: "PADKEY",writeCallback: ( _, value) => {
+              .WithFlag(0, FieldMode.Read , name: "STATUS",
+                    valueProviderCallback: _ => status)
+                .WithValueField(1, 31,FieldMode.Write , name: "PADKEY",writeCallback: ( _, value) => {
                   if (value==PadKeyUnlockValue) {
                   registerunlocked=true;
                    {  
                        for (var i=0; i<=15; i++ )
                        {
-                           EN_S[i]=EN[i];
+                          EN_S[i]=EN[i];
+                          MUX_S[i]=MUX[i];
                        }
-                        for (var i=0; i<=15; i++ )
-                       {
-                           MUX_S[i]=MUX[i];
-                       }
-                   
-                   }
-                  
-                  }
-                   this.InfoLog(" Pad key set to {0}", registerunlocked);
+                        
+                       status = true;
+                   }}
+                   this.InfoLog(" Pad key set to {0}, {1}", registerunlocked, value);
                 })
-                  .WithTaggedFlag("STATUS",31)
+               
             ;     
             Registers.std_pu_PAD_GPIO_A_0_ctl.Define(this)      
                 .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN[0]=value)
@@ -668,8 +672,9 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                 .WithTaggedFlag("PUD", 6)
                 .WithEnumField<DoubleWordRegister, IOMode>(7, 2,               
                 writeCallback: (_, value) =>  {
-                    MUX[0]=selection((IOMode)value);     
-                    },  
+                    MUX[0]=selection((IOMode)value);   
+                    UpdateStatus( Registers.std_pu_PAD_GPIO_A_0_ctl, 0); 
+                    }, 
                 name: "FUNCMAX")
                 .WithReservedBits(9, 23)    
             ;    
@@ -682,6 +687,7 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                 .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
                 writeCallback: (_, value) =>  {
                     MUX[1]=selection((IOMode)value);
+                    UpdateStatus(Registers.std_pu_PAD_GPIO_A_1_ctl,1);  
                     },
                 name: "FUNCMAX")
                 .WithReservedBits(9, 23)    
@@ -695,6 +701,7 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                 .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
                 writeCallback: (_, value) =>  {
                     MUX[2]=selection((IOMode)value);
+                    UpdateStatus(Registers.std_pu_PAD_GPIO_A_2_ctl,2); 
                     },
                 name: "FUNCMAX")
                 .WithReservedBits(9, 23)     
@@ -708,6 +715,7 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                 .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
                 writeCallback: (_, value) =>  {
                     MUX[3]=selection((IOMode)value);
+                    UpdateStatus(Registers.std_pu_PAD_GPIO_A_3_ctl,3);  
                     },
                 name: "FUNCMAX")
                 .WithReservedBits(9, 23)    
@@ -721,6 +729,7 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                 .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
                 writeCallback: (_, value) =>  {
                     MUX[4]=selection((IOMode)value);
+                    UpdateStatus(Registers.std_pu_PAD_GPIO_A_4_ctl,4); 
                     },
                 name: "FUNCMAX")
                 .WithReservedBits(9, 23)       
@@ -734,6 +743,7 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                 .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
                 writeCallback: (_, value) =>  {
                     MUX[5]=selection((IOMode)value);
+                    UpdateStatus(Registers.std_pu_PAD_GPIO_A_5_ctl,5);  
                     },
                 name: "FUNCMAX")
                 .WithReservedBits(9, 23)   
@@ -747,6 +757,7 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                 .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
                 writeCallback: (_, value) =>  {
                     MUX[6]=selection((IOMode)value);
+                    UpdateStatus(Registers.std_pu_PAD_GPIO_A_6_ctl,6); 
                     },
                 name: "FUNCMAX")
                 .WithReservedBits(9, 23)     
@@ -760,6 +771,7 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                 .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
                 writeCallback: (_, value) =>  {
                     MUX[7]=selection((IOMode)value);
+                    UpdateStatus(Registers.std_pu_PAD_GPIO_A_7_ctl,7);  
                     },
                 name: "FUNCMAX")
                 .WithReservedBits(9, 23)    
@@ -773,6 +785,7 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                 .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
                 writeCallback: (_, value) =>  {
                     MUX[8]=selection((IOMode)value);
+                    UpdateStatus(Registers.std_pu_PAD_GPIO_A_8_ctl,8); 
                     },
                 name: "FUNCMAX")
                 .WithReservedBits(9, 23)    
@@ -786,6 +799,7 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                 .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
                 writeCallback: (_, value) =>  {
                     MUX[9]=selection((IOMode)value);
+                    UpdateStatus(Registers.std_pu_PAD_GPIO_A_9_ctl,9); 
                     },
                 name: "FUNCMAX")
                 .WithReservedBits(9, 23)    
@@ -799,6 +813,7 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                 .WithEnumField<DoubleWordRegister, IOMode>(7, 2, 
                 writeCallback: (_, value) =>  {
                     MUX[10]=selection((IOMode)value);
+                    UpdateStatus(Registers.std_pu_PAD_GPIO_A_10_ctl,10); 
                     }, 
                 name: "FUNCMAX")
                 .WithReservedBits(9, 23)    
@@ -812,6 +827,7 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                 .WithEnumField<DoubleWordRegister, IOMode>(7, 2,  
                 writeCallback: (_, value) =>  {
                     MUX[11]=selection((IOMode)value);
+                    UpdateStatus(Registers.std_pu_PAD_GPIO_A_11_ctl,11); 
                     },
                 name: "FUNCMAX")
                 .WithReservedBits(9, 23)    
@@ -824,7 +840,8 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                 .WithTaggedFlag("PUD", 6)
                 .WithEnumField<DoubleWordRegister, IOMode>(7, 2,  
                 writeCallback: (_, value) =>  {
-                MUX[12]=selection((IOMode)value);
+                  MUX[12]=selection((IOMode)value);
+                  UpdateStatus(Registers.std_pu_PAD_GPIO_A_12_ctl,12); 
                     },
                 
                 name: "FUNCMAX")
@@ -839,6 +856,7 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                 .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
                 writeCallback: (_, value) =>  {
                     MUX[13]=selection((IOMode)value);
+                    UpdateStatus(Registers.std_pu_PAD_GPIO_A_13_ctl,13); 
                     },
                 name: "FUNCMAX")
                 .WithReservedBits(9, 23)    
@@ -852,6 +870,7 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                 .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
                 writeCallback: (_, value) =>  {
                     MUX[14]=selection((IOMode)value);
+                    UpdateStatus(Registers.std_pu_PAD_GPIO_A_14_ctl,14); 
                     },
                 name: "FUNCMAX")
                 .WithReservedBits(9, 23)     
@@ -865,6 +884,7 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                 .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
                 writeCallback: (_, value) =>  {
                     MUX[15]=selection((IOMode)value);
+                    UpdateStatus(Registers.std_pu_PAD_GPIO_A_15_ctl,15); 
                     },
                 name: "FUNCMAX")
                 .WithReservedBits(9, 23)    
@@ -872,14 +892,17 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
         }
         
         private const int NumberOfGPIOs = 80;
-        public const uint PadKeyUnlockValue = 0x2A6;
+        public const uint PadKeyUnlockValue = 0x2A6>>1;
         public bool registerunlocked=false;
-
+        private bool status = false; 
         private uint[] MUX=new uint[16];
         private bool[] EN = new bool[16];
         private uint[] MUX_S=new uint[16];
         private bool[] EN_S = new bool[16];
-
+        private const int GPIOPinsIndex = 16;
+        private const int FPGAPinsIndex = 32;
+        private const int AltPinsIndex = 48;
+        private const int DebugPinsIndex = 64;
         public enum IOMode
         {   MainMode = 0, 
             Fpga_pinMode = 1, 

--- a/src/Emulator/Peripherals/Peripherals/Miscellaneous/Virgo_pad.cs
+++ b/src/Emulator/Peripherals/Peripherals/Miscellaneous/Virgo_pad.cs
@@ -640,8 +640,7 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
           private void UpdateStatus(Registers reg , int i)
           {
             if (EN[i] != EN_S[i] || MUX[i] != MUX_S[i]) 
-                  status = false;       
-              
+                  status = false;        
           }
         private void PrepareRegisters()
         {          
@@ -649,20 +648,15 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
               .WithFlag(0, FieldMode.Read , name: "STATUS",
                     valueProviderCallback: _ => status)
                 .WithValueField(1, 31,FieldMode.Write , name: "PADKEY",writeCallback: ( _, value) => {
-                  if (value==PadKeyUnlockValue) {
-                  registerunlocked=true;
+                  if (value==PadKeyUnlockValue) 
                    {  
-                       for (var i=0; i<=15; i++ )
+                    for (var i=0; i<=NumberofPadOutput; i++ )
                        {
                           EN_S[i]=EN[i];
                           MUX_S[i]=MUX[i];
-                       }
-                        
+                       }   
                        status = true;
-                   }}
-                   this.InfoLog(" Pad key set to {0}, {1}", registerunlocked, value);
-                })
-               
+                   }})  
             ;     
             Registers.std_pu_PAD_GPIO_A_0_ctl.Define(this)      
                 .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN[0]=value)
@@ -892,8 +886,8 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
         }
         
         private const int NumberOfGPIOs = 80;
+        private const int NumberofPadOutput = 15;
         public const uint PadKeyUnlockValue = 0x2A6>>1;
-        public bool registerunlocked=false;
         private bool status = false; 
         private uint[] MUX=new uint[16];
         private bool[] EN = new bool[16];
@@ -904,7 +898,8 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
         private const int AltPinsIndex = 48;
         private const int DebugPinsIndex = 64;
         public enum IOMode
-        {   MainMode = 0, 
+        {   
+            MainMode = 0, 
             Fpga_pinMode = 1, 
             AlternativeMode = 2, 
             DebugMode = 3


### PR DESCRIPTION
1. Add support for Virgo pad .
2. Pad controller have 16 outputs (0-15)
3. Have 4 modes (main , fpga_gpio, ALT function and debug mode) and consists 16 inputs for 
    each mode
    (a)   Main function is in range (16-31)
    (b)   FPGA_GPIO is in range (32-47)
    (c)   ALT Function is in range (48-63)
    (d)  Debug Mode is in range  (64-80)
4. Shadow register functionality is also implemented and tested.
5. GPIO and FPGA_GPIO functionality is tested and link to test cases shared on confluence 
    https://rapidsilicon.atlassian.net/l/cp/1rP0xwLL

      