### PR TITLE
Add pad controller support

### DIFF
--- a/src/Emulator/Peripherals/Peripherals.csproj
+++ b/src/Emulator/Peripherals/Peripherals.csproj
@@ -223,6 +223,7 @@
     <Compile Include="Peripherals\SPI\STM32H7_SPI.cs" />
     <Compile Include="Peripherals\SPI\STM32WBA_SPI.cs" />
     <Compile Include="Peripherals\Timers\CC2538Watchdog.cs" />
+    <Compile Include="Peripherals\Miscellaneous\Virgo_pad.cs" />
     <Compile Include="Peripherals\USBDeprecated\USBDeviceSpeed.cs" />
     <Compile Include="Peripherals\GPIOPort\ARM_AHB_GPIO.cs" />
     <Compile Include="Peripherals\GPIOPort\EFMGPIOPort.cs" />

--- a/src/Emulator/Peripherals/Peripherals/Miscellaneous/Virgo_pad.cs
+++ b/src/Emulator/Peripherals/Peripherals/Miscellaneous/Virgo_pad.cs
@@ -17,37 +17,37 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
     {
         public Virgo_pad(IMachine machine) : base(machine, NumberOfGPIOs)
         {    
-         RegistersCollection = new DoubleWordRegisterCollection(this);
-         PrepareRegisters();
+            RegistersCollection = new DoubleWordRegisterCollection(this);
+            PrepareRegisters();
         }
 
         public override void Reset()
         {
-          base.Reset();
+            base.Reset();
         }
   
         public DoubleWordRegisterCollection RegistersCollection { get; }
         public long Size => 0x1000;
         public uint ReadDoubleWord(long offset)
         {
-          return RegistersCollection.Read(offset);
+            return RegistersCollection.Read(offset);
         }
               
         public void WriteDoubleWord(long offset, uint value)
         {    
-         RegistersCollection.Write(offset, value);
+            RegistersCollection.Write(offset, value);
         }
         
         public override void OnGPIO(int number, bool value)
         {
             if(!CheckPinNumber(number))
             {
-              return;
+                return;
             }
             
             base.OnGPIO(number, value);
             this.InfoLog("Setting pad number #{0} to value {1}", number, value);  
-           switch(number) {
+            switch(number) {
             	case 0:
               	if(EN_S[0]) {
                 	switch(MUX_S[0]) {
@@ -178,7 +178,7 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                         OnPinStateChanged(number+DebugPinsIndex, value);
                         break;
                     default:
-                      	break;
+                        break;
                     }
                   }
                 break;
@@ -363,273 +363,273 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                 case 16:
                 	if(EN_S[0] && (MUX_S[0] == 1)) {
                   	OnPinStateChanged(number-GPIOPinsIndex, value);
-                  }
-                  break;
+                    }
+                    break;
                 
                 case 17:
                 	if(EN_S[1] && (MUX_S[1] == 1)) {
                   	OnPinStateChanged(number-GPIOPinsIndex, value);
-                  }
-                  break;
+                    }
+                    break;
 
                 case 26:
                 	if(EN_S[10] && (MUX_S[10] == 1)) {
                   	OnPinStateChanged(number-GPIOPinsIndex, value);
-                  }
-                  break;
+                    }
+                    break;
 
                 case 27:
                 	if(EN_S[11] && (MUX_S[11] == 1)) {
                   	OnPinStateChanged(number-GPIOPinsIndex, value);
-                  }
-                  break;
+                    }
+                    break;
                 
                 case 28:
                 	if(EN_S[12] && (MUX_S[12] == 1)) {
                   	OnPinStateChanged(number-GPIOPinsIndex, value);
-                  }
-                  break;
+                    }
+                    break;
 
                 case 29:
                 	if(EN_S[13] && (MUX_S[13] == 1)) {
                   	OnPinStateChanged(number-GPIOPinsIndex, value);
-                  }
-                  break;
+                    }
+                    break;
                 
                 case 30:
                 	if(EN_S[14] && (MUX_S[14] == 1)) {
                   	OnPinStateChanged(number-GPIOPinsIndex, value);
-                  }
-                  break;
+                    }
+                    break;
                 
                 case 31:
                 	if(EN_S[15] && (MUX_S[15] == 1)) {
                   	OnPinStateChanged(number-GPIOPinsIndex, value);
-                  }
-                  break;
+                    }
+                    break;
 
                 case 32:
                 	if(EN_S[0] && (MUX_S[0] == 2)) {
                   	OnPinStateChanged(number-FPGAPinsIndex, value);
-                  }
-                  break;
+                    }
+                    break;
                 
                 case 33:
                 	if(EN_S[1] && (MUX_S[1] == 2)) {
                   	OnPinStateChanged(number-FPGAPinsIndex, value);
-                  }
-                  break;
+                    }
+                    break;
 
                 case 34:
                 	if(EN_S[2] && (MUX_S[2] == 2)) {
                   	OnPinStateChanged(number-FPGAPinsIndex, value);
-                  }
-                  break;
+                    }
+                    break;
                 
                 case 35:
                 	if(EN_S[3] && (MUX_S[3] == 2)) {
                   	OnPinStateChanged(number-FPGAPinsIndex, value);
-                  }
-                  break;
+                    }
+                    break;
                 
                 case 36:
                 	if(EN_S[4] && (MUX_S[4] == 2)) {
                   	OnPinStateChanged(number-FPGAPinsIndex, value);
-                  }
-                  break;
+                    }
+                    break;
 
                 case 37:
                 	if(EN_S[5] && (MUX_S[5] == 2)) {
                   	OnPinStateChanged(number-FPGAPinsIndex, value);
-                  }
-                  break;
+                    }
+                    break;
             
                 case 38:
                 	if(EN_S[6] && (MUX_S[6] == 2)) {
                   	OnPinStateChanged(number-FPGAPinsIndex, value);
-                  }
-                  break;
+                    }
+                    break;
                 
                 case 39:
                 	if(EN_S[7] && (MUX_S[7] == 2)) {
                   	OnPinStateChanged(number-FPGAPinsIndex, value);
-                  }
-                  break;
+                    }
+                    break;
                 
                 case 40:
                 	if(EN_S[8] && (MUX_S[8] == 2)) {
                   	OnPinStateChanged(number-FPGAPinsIndex, value);
-                  }
-                  break;
+                    }
+                    break;
                 
                 case 41:
                 	if(EN_S[9] && (MUX_S[9] == 2)) {
                   	OnPinStateChanged(number-FPGAPinsIndex, value);
-                  }
-                  break;
+                    }
+                    break;
                 
                 case 42:
                 	if(EN_S[10] && (MUX_S[10] == 2)) {
                   	OnPinStateChanged(number-FPGAPinsIndex, value);
-                  }
-                  break;
+                    }
+                    break;
 
                 case 43:
                 	if(EN_S[11] && (MUX_S[11] == 2)) {
                   	OnPinStateChanged(number-FPGAPinsIndex, value);
-                  }
-                  break;
+                    }
+                    break;
 
                 case 44:
                 	if(EN_S[12] && (MUX_S[12] == 2)) {
                   	OnPinStateChanged(number-FPGAPinsIndex, value);
-                  }
-                  break;
+                    }
+                    break;
 
                 case 45:
                 	if(EN_S[13] && (MUX_S[13] == 2)) {
                   	OnPinStateChanged(number-FPGAPinsIndex, value);
-                  }
-                  break;
+                    }
+                    break;
 
                 case 46:
                 	if(EN_S[14] && (MUX_S[14] == 2)) {
                   	OnPinStateChanged(number-FPGAPinsIndex, value);
-                  }
-                  break;
+                    }
+                    break;
 
                 case 47:
                 	if(EN_S[15] && (MUX_S[15] == 2)) {
                   	OnPinStateChanged(number-FPGAPinsIndex, value);
-                  }
-                  break;
+                    }
+                    break;
                 
                 case 48:
                 	if(EN_S[0] && (MUX_S[0] == 3)) {
                   	OnPinStateChanged(number-AltPinsIndex, value);
-                  }
-                  break;
+                    }
+                    break;
 
                 case 49:
                 	if(EN_S[1] && (MUX_S[1] == 3)) {
                   	OnPinStateChanged(number-AltPinsIndex, value);
-                  }
-                  break;
+                    }
+                    break;
                 
                 case 58:
                 	if(EN_S[10] && (MUX_S[10] == 3)) {
                   	OnPinStateChanged(number-AltPinsIndex, value);
-                  }
-                  break;
+                    }
+                    break;
                 
                 case 59:
                 	if(EN_S[11] && (MUX_S[11] == 3)) {
                   	OnPinStateChanged(number-AltPinsIndex, value);
-                  }
-                  break;
+                    }
+                    break;
                 
                 case 60:
                 	if(EN_S[12] && (MUX_S[12] == 3)) {
                   	OnPinStateChanged(number-AltPinsIndex, value);
-                  }
-                  break;
+                    }
+                    break;
 
                 case 61:
                 	if(EN_S[13] && (MUX_S[13] == 3)) {
                   	OnPinStateChanged(number-AltPinsIndex, value);
-                  }
-                  break;
+                    }
+                    break;
 
                 case 62:
                 	if(EN_S[14] && (MUX_S[14] == 3)) {
                   	OnPinStateChanged(number-AltPinsIndex, value);
-                  }
-                  break;
+                    }
+                    break;
 
                 case 63:
                 	if(EN_S[15] && (MUX_S[15] == 3)) {
                   	OnPinStateChanged(number-AltPinsIndex, value);
-                  }
-                  break;
+                    }
+                    break;
 
                 case 64:
                 	if(EN_S[0] && (MUX_S[0] == 4)) {
                   	OnPinStateChanged(number-DebugPinsIndex, value);
-                  }
-                  break;
+                    }
+                    break;
                 
                 case 65:
                 	if(EN_S[0] && (MUX_S[1] == 4)) {
                   	OnPinStateChanged(number-DebugPinsIndex, value);
-                  }
-                  break;
+                    }
+                    break;
                  
                 case 68:
                 	if(EN_S[4] && (MUX_S[4] == 4)) {
                   	OnPinStateChanged(number-DebugPinsIndex, value);
-                  }
-                  break;
+                    }
+                    break;
 
                 case 69:
                 	if(EN_S[5] && (MUX_S[5] == 4)) {
                   	OnPinStateChanged(number-DebugPinsIndex, value);
-                  }
-                  break;
+                    }
+                    break;
                 
                 case 70:
                 	if(EN_S[6] && (MUX_S[6] == 4)) {
                   	OnPinStateChanged(number-DebugPinsIndex, value);
-                  }
-                  break;
+                    }
+                    break;
 
                 case 71:
                 	if(EN_S[7] && (MUX_S[7] == 4)) {
                   	OnPinStateChanged(number-DebugPinsIndex, value);
-                  }
-                  break;
+                    }
+                    break;
                 
                 case 72:
                 	if(EN_S[8] && (MUX_S[8] == 4)) {
                   	OnPinStateChanged(number-DebugPinsIndex, value);
-                  }
-                  break;
+                    }
+                    break;
 
                 case 73:
                 	if(EN_S[9] && (MUX_S[9] == 4)) {
                   	OnPinStateChanged(number-DebugPinsIndex, value);
-                  }
-                  break;
+                    }
+                    break;
 
             }
                       
         } 
 
-          private void OnPinStateChanged(int number, bool current)
+        private void OnPinStateChanged(int number, bool current)
         {    
             Connections[number].Set(current);
         }
 
-           private uint selection(IOMode value)
-            { 
-                switch((IOMode)value)
-                {
-                case IOMode.MainMode:               
+        private uint selection(IOMode value)
+        { 
+            switch((IOMode)value)
+            {
+            case IOMode.MainMode:               
                 this.InfoLog("Select {0}", value);    
                 return 1;            
-                case IOMode.Fpga_pinMode:             
+            case IOMode.Fpga_pinMode:             
                 this.InfoLog("Select {0}",value);
                 return 2; 
-                case IOMode.AlternativeMode:
+            case IOMode.AlternativeMode:
                 this.InfoLog("Select {0}",value); 
                 return 3;
-                case IOMode.DebugMode:
+            case IOMode.DebugMode:
                 this.InfoLog("Select {0}",value); 
                 return 4;
-                default:
-                    this.InfoLog(" Non existitng possible value written as selection lines.");
+            default:
+                this.InfoLog(" Non existitng possible value written as selection lines.");
                 return 0;
-                }
             }
+        }
           
           private void UpdateStatus(Registers reg , int i)
           {
@@ -646,8 +646,8 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                    {  
                     for (var i=0; i<=NumberofPadOutput; i++ )
                        {
-                          EN_S[i]=EN[i];
-                          MUX_S[i]=MUX[i];
+                            EN_S[i]=EN[i];
+                            MUX_S[i]=MUX[i];
                        }   
                        status = true;
                    }})  
@@ -659,10 +659,11 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                 .WithTaggedFlag("PUE", 5)
                 .WithTaggedFlag("PUD", 6)
                 .WithEnumField<DoubleWordRegister, IOMode>(7, 2,               
-                writeCallback: (_, value) =>  {
+                writeCallback: (_, value) =>  
+                {
                     MUX[0]=selection((IOMode)value);   
                     UpdateStatus( Registers.std_pu_PAD_GPIO_A_0_ctl, 0); 
-                    }, 
+                }, 
                 name: "FUNCMAX")
                 .WithReservedBits(9, 23)    
             ;    
@@ -673,10 +674,11 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                 .WithTaggedFlag("PUE", 5)
                 .WithTaggedFlag("PUD", 6)
                 .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
-                writeCallback: (_, value) =>  {
+                writeCallback: (_, value) =>  
+                {
                     MUX[1]=selection((IOMode)value);
                     UpdateStatus(Registers.std_pu_PAD_GPIO_A_1_ctl,1);  
-                    },
+                },
                 name: "FUNCMAX")
                 .WithReservedBits(9, 23)    
             ; 
@@ -687,10 +689,11 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                 .WithTaggedFlag("PUE", 5)
                 .WithTaggedFlag("PUD", 6)
                 .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
-                writeCallback: (_, value) =>  {
+                writeCallback: (_, value) =>  
+                {
                     MUX[2]=selection((IOMode)value);
                     UpdateStatus(Registers.std_pu_PAD_GPIO_A_2_ctl,2); 
-                    },
+                },
                 name: "FUNCMAX")
                 .WithReservedBits(9, 23)     
             ;  
@@ -701,10 +704,11 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                 .WithTaggedFlag("PUE", 5)
                 .WithTaggedFlag("PUD", 6)
                 .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
-                writeCallback: (_, value) =>  {
+                writeCallback: (_, value) =>  
+                {
                     MUX[3]=selection((IOMode)value);
                     UpdateStatus(Registers.std_pu_PAD_GPIO_A_3_ctl,3);  
-                    },
+                },
                 name: "FUNCMAX")
                 .WithReservedBits(9, 23)    
             ; 
@@ -715,10 +719,11 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                 .WithTaggedFlag("PUE", 5)
                 .WithTaggedFlag("PUD", 6)
                 .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
-                writeCallback: (_, value) =>  {
+                writeCallback: (_, value) =>  
+                {
                     MUX[4]=selection((IOMode)value);
                     UpdateStatus(Registers.std_pu_PAD_GPIO_A_4_ctl,4); 
-                    },
+                },
                 name: "FUNCMAX")
                 .WithReservedBits(9, 23)       
             ;
@@ -729,10 +734,11 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                 .WithTaggedFlag("PUE", 5)
                 .WithTaggedFlag("PUD", 6)
                 .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
-                writeCallback: (_, value) =>  {
+                writeCallback: (_, value) =>  
+                {
                     MUX[5]=selection((IOMode)value);
                     UpdateStatus(Registers.std_pu_PAD_GPIO_A_5_ctl,5);  
-                    },
+                },
                 name: "FUNCMAX")
                 .WithReservedBits(9, 23)   
             ;
@@ -743,10 +749,11 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                 .WithTaggedFlag("PUE", 5)
                 .WithTaggedFlag("PUD", 6)
                 .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
-                writeCallback: (_, value) =>  {
+                writeCallback: (_, value) =>  
+                {
                     MUX[6]=selection((IOMode)value);
                     UpdateStatus(Registers.std_pu_PAD_GPIO_A_6_ctl,6); 
-                    },
+                },
                 name: "FUNCMAX")
                 .WithReservedBits(9, 23)     
             ;
@@ -757,10 +764,11 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                 .WithTaggedFlag("PUE", 5)
                 .WithTaggedFlag("PUD", 6)
                 .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
-                writeCallback: (_, value) =>  {
+                writeCallback: (_, value) =>  
+                {
                     MUX[7]=selection((IOMode)value);
                     UpdateStatus(Registers.std_pu_PAD_GPIO_A_7_ctl,7);  
-                    },
+                },
                 name: "FUNCMAX")
                 .WithReservedBits(9, 23)    
             ;
@@ -771,10 +779,11 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                 .WithTaggedFlag("PUE", 5)
                 .WithTaggedFlag("PUD", 6)
                 .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
-                writeCallback: (_, value) =>  {
+                writeCallback: (_, value) =>  
+                {
                     MUX[8]=selection((IOMode)value);
                     UpdateStatus(Registers.std_pu_PAD_GPIO_A_8_ctl,8); 
-                    },
+                },
                 name: "FUNCMAX")
                 .WithReservedBits(9, 23)    
             ;
@@ -785,10 +794,11 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                 .WithTaggedFlag("PUE", 5)
                 .WithTaggedFlag("PUD", 6)
                 .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
-                writeCallback: (_, value) =>  {
+                writeCallback: (_, value) =>  
+                {
                     MUX[9]=selection((IOMode)value);
                     UpdateStatus(Registers.std_pu_PAD_GPIO_A_9_ctl,9); 
-                    },
+                },
                 name: "FUNCMAX")
                 .WithReservedBits(9, 23)    
             ;
@@ -799,10 +809,11 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                 .WithTaggedFlag("PUE", 5)
                 .WithTaggedFlag("PUD", 6)
                 .WithEnumField<DoubleWordRegister, IOMode>(7, 2, 
-                writeCallback: (_, value) =>  {
+                writeCallback: (_, value) =>  
+                {
                     MUX[10]=selection((IOMode)value);
                     UpdateStatus(Registers.std_pu_PAD_GPIO_A_10_ctl,10); 
-                    }, 
+                }, 
                 name: "FUNCMAX")
                 .WithReservedBits(9, 23)    
             ;  
@@ -813,10 +824,11 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                 .WithTaggedFlag("PUE", 5)
                 .WithTaggedFlag("PUD", 6)
                 .WithEnumField<DoubleWordRegister, IOMode>(7, 2,  
-                writeCallback: (_, value) =>  {
+                writeCallback: (_, value) =>  
+                {
                     MUX[11]=selection((IOMode)value);
                     UpdateStatus(Registers.std_pu_PAD_GPIO_A_11_ctl,11); 
-                    },
+                },
                 name: "FUNCMAX")
                 .WithReservedBits(9, 23)    
             ;  
@@ -827,10 +839,11 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                 .WithTaggedFlag("PUE", 5)
                 .WithTaggedFlag("PUD", 6)
                 .WithEnumField<DoubleWordRegister, IOMode>(7, 2,  
-                writeCallback: (_, value) =>  {
-                  MUX[12]=selection((IOMode)value);
-                  UpdateStatus(Registers.std_pu_PAD_GPIO_A_12_ctl,12); 
-                    },
+                writeCallback: (_, value) =>  
+                {
+                    MUX[12]=selection((IOMode)value);
+                    UpdateStatus(Registers.std_pu_PAD_GPIO_A_12_ctl,12); 
+                },
                 
                 name: "FUNCMAX")
                 .WithReservedBits(9, 23)     
@@ -842,10 +855,11 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                 .WithTaggedFlag("PUE", 5)
                 .WithTaggedFlag("PUD", 6)
                 .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
-                writeCallback: (_, value) =>  {
+                writeCallback: (_, value) =>  
+                {
                     MUX[13]=selection((IOMode)value);
                     UpdateStatus(Registers.std_pu_PAD_GPIO_A_13_ctl,13); 
-                    },
+                },
                 name: "FUNCMAX")
                 .WithReservedBits(9, 23)    
             ;
@@ -856,10 +870,11 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                 .WithTaggedFlag("PUE", 5)
                 .WithTaggedFlag("PUD", 6)
                 .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
-                writeCallback: (_, value) =>  {
+                writeCallback: (_, value) =>  
+                {
                     MUX[14]=selection((IOMode)value);
                     UpdateStatus(Registers.std_pu_PAD_GPIO_A_14_ctl,14); 
-                    },
+                },
                 name: "FUNCMAX")
                 .WithReservedBits(9, 23)     
             ;
@@ -870,10 +885,11 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                 .WithTaggedFlag("PUE", 5)
                 .WithTaggedFlag("PUD", 6)
                 .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
-                writeCallback: (_, value) =>  {
+                writeCallback: (_, value) =>  
+                {
                     MUX[15]=selection((IOMode)value);
                     UpdateStatus(Registers.std_pu_PAD_GPIO_A_15_ctl,15); 
-                    },
+                },
                 name: "FUNCMAX")
                 .WithReservedBits(9, 23)    
             ;              

--- a/src/Emulator/Peripherals/Peripherals/Miscellaneous/Virgo_pad.cs
+++ b/src/Emulator/Peripherals/Peripherals/Miscellaneous/Virgo_pad.cs
@@ -1,0 +1,923 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Runtime.InteropServices;
+using Antmicro.Renode.Exceptions;
+using Antmicro.Renode.Logging;
+using System.Linq;
+using Antmicro.Renode.Core;
+using Antmicro.Renode.Core.Structure.Registers;
+using Antmicro.Renode.Peripherals.Bus;
+using Antmicro.Renode.Utilities;
+using Antmicro.Renode.Peripherals.GPIOPort;
+
+namespace Antmicro.Renode.Peripherals.Miscellaneous
+{
+    public class Virgo_pad : BaseGPIOPort, IProvidesRegisterCollection<DoubleWordRegisterCollection>, IDoubleWordPeripheral, IKnownSize,IGPIOReceiver
+    {
+        public Virgo_pad(IMachine machine) : base(machine, NumberOfGPIOs)
+        {    
+         RegistersCollection = new DoubleWordRegisterCollection(this);
+         PrepareRegisters();
+        }
+
+        public override void Reset()
+        {
+          base.Reset();
+        }
+  
+        public DoubleWordRegisterCollection RegistersCollection { get; }
+        public long Size => 0x1000;
+        public uint ReadDoubleWord(long offset)
+        {
+          return RegistersCollection.Read(offset);
+        }
+              
+        public void WriteDoubleWord(long offset, uint value)
+        {    
+         RegistersCollection.Write(offset, value);
+        }
+        
+        public override void OnGPIO(int number, bool value)
+        {
+            if(!CheckPinNumber(number))
+            {
+              return;
+            }
+            
+            base.OnGPIO(number, value);
+            this.InfoLog("Setting pad number #{0} to value {1}", number, value);  
+           switch(number) {
+            	case 0:
+              	if(EN_S[0]) {
+                	switch(MUX_S[0]) {
+                  	case 1: 
+                    	OnPinStateChanged(number+GPIOPinsIndex, value);
+                        break;
+                    case 2:
+                    	OnPinStateChanged(number+FPGAPinsIndex, value);
+                        break;
+                    case 3:
+                        OnPinStateChanged(number+AltPinsIndex, value);
+                        break;
+                    case 4:
+                        OnPinStateChanged(number+DebugPinsIndex, value);
+                        break;
+                    default:
+                    	break;
+                  }
+                }
+                break;
+                
+                case 1:
+                	if(EN_S[1]) {
+                  	switch(MUX_S[1]) {
+                    case 1:
+                        OnPinStateChanged(number+GPIOPinsIndex, value);
+                        break;
+                    case 2:
+                      	OnPinStateChanged(number+FPGAPinsIndex, value);
+                        break;
+                    case 3:
+                        OnPinStateChanged(number+AltPinsIndex, value);
+                        break;
+                    case 4:
+                        OnPinStateChanged(number+DebugPinsIndex, value);
+                        break;
+                    default:
+                      	break;
+                    }
+                  }
+                break;
+
+                case 2:
+                	if(EN_S[2]) {
+                  	switch(MUX_S[2]) {
+                    case 1:
+                        break;
+                    case 2:
+                      	OnPinStateChanged(number+FPGAPinsIndex, value);
+                        break;
+                    case 3:
+                        break;
+                    case 4:
+                        break;
+                    default:
+                      	break;
+                    }
+                  }
+                break; 
+
+                case 3:
+                	if(EN_S[3]) {
+                  	switch(MUX_S[3]) {
+                    case 1:
+                        break;
+                    case 2:
+                      	OnPinStateChanged(number+FPGAPinsIndex, value);
+                        break;
+                    case 3:
+                        break;
+                    case 4:
+                        break;
+                    default:
+                      	break;
+                    }
+                  }
+                break;
+
+                case 4:
+                	if(EN_S[4]) {
+                  	switch(MUX_S[4]) {
+                    case 1:
+                        break;
+                    case 2:
+                      	OnPinStateChanged(number+FPGAPinsIndex, value);
+                        break;
+                    case 3:
+                        break;
+                    case 4:
+                        OnPinStateChanged(number+DebugPinsIndex, value);
+                        break;
+                    default:
+                      	break;
+                    }
+                  }
+                break;
+
+                case 5:
+                	if(EN_S[5]) {
+                  	switch(MUX_S[5]) {
+                    case 1:
+                        break;
+                    case 2:
+                      	OnPinStateChanged(number+FPGAPinsIndex, value);
+                        break;
+                    case 3:
+                        break;
+                    case 4:
+                        OnPinStateChanged(number+DebugPinsIndex, value);
+                        break;
+                    default:
+                      	break;
+                    }
+                  }
+                break;
+
+                case 6:
+                	if(EN_S[6]) {
+                  	switch(MUX_S[6]) {
+                    case 1:
+                        break;
+                    case 2:
+                      	OnPinStateChanged(number+FPGAPinsIndex, value);
+                        break;
+                    case 3:
+                        break;
+                    case 4:
+                        OnPinStateChanged(number+DebugPinsIndex, value);
+                        break;
+                    default:
+                      	break;
+                    }
+                  }
+                break;
+
+                case 7:
+                	if(EN_S[7]) {
+                  	switch(MUX_S[7]) {
+                    case 1:
+                        break;
+                    case 2:
+                      	OnPinStateChanged(number+FPGAPinsIndex, value);
+                        break;
+                    case 3:
+                        break;
+                    case 4:
+                        OnPinStateChanged(number+DebugPinsIndex, value);
+                        break;
+                    default:
+                      	break;
+                    }
+                  }
+                break;
+            
+                case 8:
+                	if(EN_S[8]) {
+                  	switch(MUX_S[8]) {
+                    case 1:
+                        break;
+                    case 2:
+                      	OnPinStateChanged(number+FPGAPinsIndex, value);
+                        break;
+                    case 3:
+                        break;
+                    case 4:
+                        OnPinStateChanged(number+DebugPinsIndex, value);
+                        break;
+                    default:
+                      	break;
+                    }
+                  }
+                break;
+                
+                case 9:
+                	if(EN_S[9]) {
+                  	switch(MUX_S[10]) {
+                    case 1:
+                        break;
+                    case 2:
+                      	OnPinStateChanged(number+FPGAPinsIndex , value);
+                        break;
+                    case 3:
+                        break;
+                    case 4:
+                        OnPinStateChanged(number+DebugPinsIndex, value);
+                        break;
+                    default:
+                      	break;
+                    }
+                  }
+                break;
+
+                case 10:
+                	if(EN_S[10]) {
+                  	switch(MUX_S[10]) {
+                    case 1:
+                        OnPinStateChanged(number+GPIOPinsIndex, value);
+                        break;
+                    case 2:
+                      	OnPinStateChanged(number+FPGAPinsIndex, value);
+                        break;
+                    case 3:
+                        OnPinStateChanged(number+AltPinsIndex, value);
+                        break;
+                    case 4:
+                        break;
+                    default:
+                      	break;
+                    }
+                  }
+                break;
+
+                case 11:
+                	if(EN_S[11]) {
+                  	switch(MUX_S[11]) {
+                    case 1:
+                        OnPinStateChanged(number+GPIOPinsIndex, value);
+                        break;
+                    case 2:
+                      	OnPinStateChanged(number+FPGAPinsIndex, value);
+                        break;
+                    case 3:
+                        OnPinStateChanged(number+AltPinsIndex, value);
+                        break;
+                    case 4:
+                        break;
+                    default:
+                      	break;
+                    }
+                  }
+                break;
+
+                case 12:
+                	if(EN_S[12]) {
+                  	switch(MUX_S[12]) {
+                    case 1:
+                        OnPinStateChanged(number+GPIOPinsIndex, value);
+                        break;
+                    case 2:
+                      	OnPinStateChanged(number+FPGAPinsIndex, value);
+                        break;
+                    case 3:
+                        OnPinStateChanged(number+AltPinsIndex, value);
+                        break;
+                    case 4:
+                        break;
+                    default:
+                      	break;
+                    }
+                  }
+                break;
+                
+                case 13:
+                	if(EN_S[13]) {
+                  	switch(MUX_S[13]) {
+                    case 1:
+                        OnPinStateChanged(number+GPIOPinsIndex, value);
+                        break;
+                    case 2:
+                      	OnPinStateChanged(number+FPGAPinsIndex, value);
+                        break;
+                    case 3:
+                        OnPinStateChanged(number+AltPinsIndex, value);
+                        break;
+                    case 4:
+                        break;
+                    default:
+                      	break;
+                    }
+                  }
+                break;
+
+                case 14:
+                	if(EN_S[14]) {
+                  	switch(MUX_S[14]) {
+                    case 1:
+                        OnPinStateChanged(number+GPIOPinsIndex, value);
+                        break;
+                    case 2:
+                      	OnPinStateChanged(number+FPGAPinsIndex, value);
+                        break;
+                    case 3:
+                        OnPinStateChanged(number+AltPinsIndex, value);
+                        break;
+                    case 4:
+                        break;
+                    default:
+                      	break;
+                    }
+                  }
+                break;
+
+                case 15:
+                	if(EN_S[15]) {
+                  	switch(MUX_S[15]) {
+                    case 1:
+                        OnPinStateChanged(number+GPIOPinsIndex, value);
+                        break;
+                    case 2:
+                      	OnPinStateChanged(number+FPGAPinsIndex, value);
+                        break;
+                    case 3:
+                        OnPinStateChanged(number+AltPinsIndex, value);
+                        break;
+                    case 4:
+                        break;
+                    default:
+                      	break;
+                    }
+                  }
+                break;
+
+                case 16:
+                	if(EN_S[0] && (MUX_S[0] == 1)) {
+                  	OnPinStateChanged(number-GPIOPinsIndex, value);
+                  }
+                  break;
+                
+                case 17:
+                	if(EN_S[1] && (MUX_S[1] == 1)) {
+                  	OnPinStateChanged(number-GPIOPinsIndex, value);
+                  }
+                  break;
+
+                case 26:
+                	if(EN_S[10] && (MUX_S[10] == 1)) {
+                  	OnPinStateChanged(number-GPIOPinsIndex, value);
+                  }
+                  break;
+
+                case 27:
+                	if(EN_S[11] && (MUX_S[11] == 1)) {
+                  	OnPinStateChanged(number-GPIOPinsIndex, value);
+                  }
+                  break;
+                
+                case 28:
+                	if(EN_S[12] && (MUX_S[12] == 1)) {
+                  	OnPinStateChanged(number-GPIOPinsIndex, value);
+                  }
+                  break;
+
+                case 29:
+                	if(EN_S[13] && (MUX_S[13] == 1)) {
+                  	OnPinStateChanged(number-GPIOPinsIndex, value);
+                  }
+                  break;
+                
+                case 30:
+                	if(EN_S[14] && (MUX_S[14] == 1)) {
+                  	OnPinStateChanged(number-GPIOPinsIndex, value);
+                  }
+                  break;
+                
+                case 31:
+                	if(EN_S[15] && (MUX_S[15] == 1)) {
+                  	OnPinStateChanged(number-GPIOPinsIndex, value);
+                  }
+                  break;
+
+                case 32:
+                	if(EN_S[0] && (MUX_S[0] == 2)) {
+                  	OnPinStateChanged(number-FPGAPinsIndex, value);
+                  }
+                  break;
+                
+                case 33:
+                	if(EN_S[1] && (MUX_S[1] == 2)) {
+                  	OnPinStateChanged(number-FPGAPinsIndex, value);
+                  }
+                  break;
+
+                case 34:
+                	if(EN_S[2] && (MUX_S[2] == 2)) {
+                  	OnPinStateChanged(number-FPGAPinsIndex, value);
+                  }
+                  break;
+                
+                case 35:
+                	if(EN_S[3] && (MUX_S[3] == 2)) {
+                  	OnPinStateChanged(number-FPGAPinsIndex, value);
+                  }
+                  break;
+                
+                case 36:
+                	if(EN_S[4] && (MUX_S[4] == 2)) {
+                  	OnPinStateChanged(number-FPGAPinsIndex, value);
+                  }
+                  break;
+
+                case 37:
+                	if(EN_S[5] && (MUX_S[5] == 2)) {
+                  	OnPinStateChanged(number-FPGAPinsIndex, value);
+                  }
+                  break;
+            
+                case 38:
+                	if(EN_S[6] && (MUX_S[6] == 2)) {
+                  	OnPinStateChanged(number-FPGAPinsIndex, value);
+                  }
+                  break;
+                
+                case 39:
+                	if(EN_S[7] && (MUX_S[7] == 2)) {
+                  	OnPinStateChanged(number-FPGAPinsIndex, value);
+                  }
+                  break;
+                
+                case 40:
+                	if(EN_S[8] && (MUX_S[8] == 2)) {
+                  	OnPinStateChanged(number-FPGAPinsIndex, value);
+                  }
+                  break;
+                
+                case 41:
+                	if(EN_S[9] && (MUX_S[9] == 2)) {
+                  	OnPinStateChanged(number-FPGAPinsIndex, value);
+                  }
+                  break;
+                
+                case 42:
+                	if(EN_S[10] && (MUX_S[10] == 2)) {
+                  	OnPinStateChanged(number-FPGAPinsIndex, value);
+                  }
+                  break;
+
+                case 43:
+                	if(EN_S[11] && (MUX_S[11] == 2)) {
+                  	OnPinStateChanged(number-FPGAPinsIndex, value);
+                  }
+                  break;
+
+                case 44:
+                	if(EN_S[12] && (MUX_S[12] == 2)) {
+                  	OnPinStateChanged(number-FPGAPinsIndex, value);
+                  }
+                  break;
+
+                case 45:
+                	if(EN_S[13] && (MUX_S[13] == 2)) {
+                  	OnPinStateChanged(number-FPGAPinsIndex, value);
+                  }
+                  break;
+
+                case 46:
+                	if(EN_S[14] && (MUX_S[14] == 2)) {
+                  	OnPinStateChanged(number-FPGAPinsIndex, value);
+                  }
+                  break;
+
+                case 47:
+                	if(EN_S[15] && (MUX_S[15] == 2)) {
+                  	OnPinStateChanged(number-FPGAPinsIndex, value);
+                  }
+                  break;
+                
+                case 48:
+                	if(EN_S[0] && (MUX_S[0] == 3)) {
+                  	OnPinStateChanged(number-AltPinsIndex, value);
+                  }
+                  break;
+
+                case 49:
+                	if(EN_S[1] && (MUX_S[1] == 3)) {
+                  	OnPinStateChanged(number-AltPinsIndex, value);
+                  }
+                  break;
+                
+                case 58:
+                	if(EN_S[10] && (MUX_S[10] == 3)) {
+                  	OnPinStateChanged(number-AltPinsIndex, value);
+                  }
+                  break;
+                
+                case 59:
+                	if(EN_S[11] && (MUX_S[11] == 3)) {
+                  	OnPinStateChanged(number-AltPinsIndex, value);
+                  }
+                  break;
+                
+                case 60:
+                	if(EN_S[12] && (MUX_S[12] == 3)) {
+                  	OnPinStateChanged(number-AltPinsIndex, value);
+                  }
+                  break;
+
+                case 61:
+                	if(EN_S[13] && (MUX_S[13] == 3)) {
+                  	OnPinStateChanged(number-AltPinsIndex, value);
+                  }
+                  break;
+
+                case 62:
+                	if(EN_S[14] && (MUX_S[14] == 3)) {
+                  	OnPinStateChanged(number-AltPinsIndex, value);
+                  }
+                  break;
+
+                case 63:
+                	if(EN_S[15] && (MUX_S[15] == 3)) {
+                  	OnPinStateChanged(number-AltPinsIndex, value);
+                  }
+                  break;
+
+                case 64:
+                	if(EN_S[0] && (MUX_S[0] == 4)) {
+                  	OnPinStateChanged(number-DebugPinsIndex, value);
+                  }
+                  break;
+                
+                case 65:
+                	if(EN_S[0] && (MUX_S[1] == 4)) {
+                  	OnPinStateChanged(number-DebugPinsIndex, value);
+                  }
+                  break;
+                 
+                case 68:
+                	if(EN_S[4] && (MUX_S[4] == 4)) {
+                  	OnPinStateChanged(number-DebugPinsIndex, value);
+                  }
+                  break;
+
+                case 69:
+                	if(EN_S[5] && (MUX_S[5] == 4)) {
+                  	OnPinStateChanged(number-DebugPinsIndex, value);
+                  }
+                  break;
+                
+                case 70:
+                	if(EN_S[6] && (MUX_S[6] == 4)) {
+                  	OnPinStateChanged(number-DebugPinsIndex, value);
+                  }
+                  break;
+
+                case 71:
+                	if(EN_S[7] && (MUX_S[7] == 4)) {
+                  	OnPinStateChanged(number-DebugPinsIndex, value);
+                  }
+                  break;
+                
+                case 72:
+                	if(EN_S[8] && (MUX_S[8] == 4)) {
+                  	OnPinStateChanged(number-DebugPinsIndex, value);
+                  }
+                  break;
+
+                case 73:
+                	if(EN_S[9] && (MUX_S[9] == 4)) {
+                  	OnPinStateChanged(number-DebugPinsIndex, value);
+                  }
+                  break;
+
+            }
+                      
+        } 
+
+          private void OnPinStateChanged(int number, bool current)
+        {    
+            Connections[number].Set(current);
+        }
+
+           private uint selection(IOMode value)
+            { 
+                switch((IOMode)value)
+                {
+                case IOMode.MainMode:               
+                this.InfoLog("Select {0}", value);    
+                return 1;            
+                case IOMode.Fpga_pinMode:             
+                this.InfoLog("Select {0}",value);
+                return 2; 
+                case IOMode.AlternativeMode:
+                this.InfoLog("Select {0}",value); 
+                return 3;
+                case IOMode.DebugMode:
+                this.InfoLog("Select {0}",value); 
+                return 4;
+                default:
+                    this.InfoLog(" Non existitng possible value written as selection lines.");
+                return 0;
+                }
+            }
+          
+          private void UpdateStatus(Registers reg , int i)
+          {
+            if (EN[i] != EN_S[i] || MUX[i] != MUX_S[i]) 
+                  status = false;        
+          }
+        private void PrepareRegisters()
+        {          
+            Registers.pad_csr.Define(this)
+              .WithFlag(0, FieldMode.Read , name: "STATUS",
+                    valueProviderCallback: _ => status)
+                .WithValueField(1, 31,FieldMode.Write , name: "PADKEY",writeCallback: ( _, value) => {
+                  if (value==PadKeyUnlockValue) 
+                   {  
+                    for (var i=0; i<=NumberofPadOutput; i++ )
+                       {
+                          EN_S[i]=EN[i];
+                          MUX_S[i]=MUX[i];
+                       }   
+                       status = true;
+                   }})  
+            ;     
+            Registers.std_pu_PAD_GPIO_A_0_ctl.Define(this)      
+                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN[0]=value)
+                .WithTag("DS", 1, 2)
+                .WithReservedBits(3, 2)
+                .WithTaggedFlag("PUE", 5)
+                .WithTaggedFlag("PUD", 6)
+                .WithEnumField<DoubleWordRegister, IOMode>(7, 2,               
+                writeCallback: (_, value) =>  {
+                    MUX[0]=selection((IOMode)value);   
+                    UpdateStatus( Registers.std_pu_PAD_GPIO_A_0_ctl, 0); 
+                    }, 
+                name: "FUNCMAX")
+                .WithReservedBits(9, 23)    
+            ;    
+            Registers.std_pu_PAD_GPIO_A_1_ctl.Define(this)
+                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN[1]=value)
+                .WithTag("DS", 1, 2)
+                .WithReservedBits(3, 2)
+                .WithTaggedFlag("PUE", 5)
+                .WithTaggedFlag("PUD", 6)
+                .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
+                writeCallback: (_, value) =>  {
+                    MUX[1]=selection((IOMode)value);
+                    UpdateStatus(Registers.std_pu_PAD_GPIO_A_1_ctl,1);  
+                    },
+                name: "FUNCMAX")
+                .WithReservedBits(9, 23)    
+            ; 
+            Registers.std_pu_PAD_GPIO_A_2_ctl.Define(this)
+                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN[2]=value)
+                .WithTag("DS", 1, 2)
+                .WithReservedBits(3, 2)
+                .WithTaggedFlag("PUE", 5)
+                .WithTaggedFlag("PUD", 6)
+                .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
+                writeCallback: (_, value) =>  {
+                    MUX[2]=selection((IOMode)value);
+                    UpdateStatus(Registers.std_pu_PAD_GPIO_A_2_ctl,2); 
+                    },
+                name: "FUNCMAX")
+                .WithReservedBits(9, 23)     
+            ;  
+            Registers.std_pu_PAD_GPIO_A_3_ctl.Define(this)
+                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN[3]=value)
+                .WithTag("DS", 1, 2)
+                .WithReservedBits(3, 2)
+                .WithTaggedFlag("PUE", 5)
+                .WithTaggedFlag("PUD", 6)
+                .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
+                writeCallback: (_, value) =>  {
+                    MUX[3]=selection((IOMode)value);
+                    UpdateStatus(Registers.std_pu_PAD_GPIO_A_3_ctl,3);  
+                    },
+                name: "FUNCMAX")
+                .WithReservedBits(9, 23)    
+            ; 
+            Registers.std_pu_PAD_GPIO_A_4_ctl.Define(this)
+                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN[4]=value)
+                .WithTag("DS", 1, 2)
+                .WithReservedBits(3, 2)
+                .WithTaggedFlag("PUE", 5)
+                .WithTaggedFlag("PUD", 6)
+                .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
+                writeCallback: (_, value) =>  {
+                    MUX[4]=selection((IOMode)value);
+                    UpdateStatus(Registers.std_pu_PAD_GPIO_A_4_ctl,4); 
+                    },
+                name: "FUNCMAX")
+                .WithReservedBits(9, 23)       
+            ;
+            Registers.std_pu_PAD_GPIO_A_5_ctl.Define(this)
+                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN[5]=value)
+                .WithTag("DS", 1, 2)
+                .WithReservedBits(3, 2)
+                .WithTaggedFlag("PUE", 5)
+                .WithTaggedFlag("PUD", 6)
+                .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
+                writeCallback: (_, value) =>  {
+                    MUX[5]=selection((IOMode)value);
+                    UpdateStatus(Registers.std_pu_PAD_GPIO_A_5_ctl,5);  
+                    },
+                name: "FUNCMAX")
+                .WithReservedBits(9, 23)   
+            ;
+            Registers.std_pu_PAD_GPIO_A_6_ctl.Define(this)
+                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN[6]=value)
+                .WithTag("DS", 1, 2)
+                .WithReservedBits(3, 2)
+                .WithTaggedFlag("PUE", 5)
+                .WithTaggedFlag("PUD", 6)
+                .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
+                writeCallback: (_, value) =>  {
+                    MUX[6]=selection((IOMode)value);
+                    UpdateStatus(Registers.std_pu_PAD_GPIO_A_6_ctl,6); 
+                    },
+                name: "FUNCMAX")
+                .WithReservedBits(9, 23)     
+            ;
+            Registers.std_pu_PAD_GPIO_A_7_ctl.Define(this)
+                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN[7]=value)
+                .WithTag("DS", 1, 2)
+                .WithReservedBits(3, 2)
+                .WithTaggedFlag("PUE", 5)
+                .WithTaggedFlag("PUD", 6)
+                .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
+                writeCallback: (_, value) =>  {
+                    MUX[7]=selection((IOMode)value);
+                    UpdateStatus(Registers.std_pu_PAD_GPIO_A_7_ctl,7);  
+                    },
+                name: "FUNCMAX")
+                .WithReservedBits(9, 23)    
+            ;
+            Registers.std_pu_PAD_GPIO_A_8_ctl.Define(this)
+                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN[8]=value)
+                .WithTag("DS", 1, 2)
+                .WithReservedBits(3, 2)
+                .WithTaggedFlag("PUE", 5)
+                .WithTaggedFlag("PUD", 6)
+                .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
+                writeCallback: (_, value) =>  {
+                    MUX[8]=selection((IOMode)value);
+                    UpdateStatus(Registers.std_pu_PAD_GPIO_A_8_ctl,8); 
+                    },
+                name: "FUNCMAX")
+                .WithReservedBits(9, 23)    
+            ;
+            Registers.std_pu_PAD_GPIO_A_9_ctl.Define(this)
+                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN[9]=value)
+                .WithTag("DS", 1, 2)
+                .WithReservedBits(3, 2)
+                .WithTaggedFlag("PUE", 5)
+                .WithTaggedFlag("PUD", 6)
+                .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
+                writeCallback: (_, value) =>  {
+                    MUX[9]=selection((IOMode)value);
+                    UpdateStatus(Registers.std_pu_PAD_GPIO_A_9_ctl,9); 
+                    },
+                name: "FUNCMAX")
+                .WithReservedBits(9, 23)    
+            ;
+            Registers.std_pu_PAD_GPIO_A_10_ctl.Define(this)
+                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN[10]=value)
+                .WithTag("DS", 1, 2)
+                .WithReservedBits(3, 2)
+                .WithTaggedFlag("PUE", 5)
+                .WithTaggedFlag("PUD", 6)
+                .WithEnumField<DoubleWordRegister, IOMode>(7, 2, 
+                writeCallback: (_, value) =>  {
+                    MUX[10]=selection((IOMode)value);
+                    UpdateStatus(Registers.std_pu_PAD_GPIO_A_10_ctl,10); 
+                    }, 
+                name: "FUNCMAX")
+                .WithReservedBits(9, 23)    
+            ;  
+            Registers.std_pu_PAD_GPIO_A_11_ctl.Define(this)
+                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN[11]=value)
+                .WithTag("DS", 1, 2)
+                .WithReservedBits(3, 2)
+                .WithTaggedFlag("PUE", 5)
+                .WithTaggedFlag("PUD", 6)
+                .WithEnumField<DoubleWordRegister, IOMode>(7, 2,  
+                writeCallback: (_, value) =>  {
+                    MUX[11]=selection((IOMode)value);
+                    UpdateStatus(Registers.std_pu_PAD_GPIO_A_11_ctl,11); 
+                    },
+                name: "FUNCMAX")
+                .WithReservedBits(9, 23)    
+            ;  
+            Registers.std_pu_PAD_GPIO_A_12_ctl.Define(this)
+                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN[12]=value)
+                .WithTag("DS", 1, 2)
+                .WithReservedBits(3, 2)
+                .WithTaggedFlag("PUE", 5)
+                .WithTaggedFlag("PUD", 6)
+                .WithEnumField<DoubleWordRegister, IOMode>(7, 2,  
+                writeCallback: (_, value) =>  {
+                  MUX[12]=selection((IOMode)value);
+                  UpdateStatus(Registers.std_pu_PAD_GPIO_A_12_ctl,12); 
+                    },
+                
+                name: "FUNCMAX")
+                .WithReservedBits(9, 23)     
+            ;  
+            Registers.std_pu_PAD_GPIO_A_13_ctl.Define(this)
+                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN[13]=value)
+                .WithTag("DS", 1, 2)
+                .WithReservedBits(3, 2)
+                .WithTaggedFlag("PUE", 5)
+                .WithTaggedFlag("PUD", 6)
+                .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
+                writeCallback: (_, value) =>  {
+                    MUX[13]=selection((IOMode)value);
+                    UpdateStatus(Registers.std_pu_PAD_GPIO_A_13_ctl,13); 
+                    },
+                name: "FUNCMAX")
+                .WithReservedBits(9, 23)    
+            ;
+            Registers.std_pu_PAD_GPIO_A_14_ctl.Define(this)
+                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN[14]=value)
+                .WithTag("DS", 1, 2)
+                .WithReservedBits(3, 2)
+                .WithTaggedFlag("PUE", 5)
+                .WithTaggedFlag("PUD", 6)
+                .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
+                writeCallback: (_, value) =>  {
+                    MUX[14]=selection((IOMode)value);
+                    UpdateStatus(Registers.std_pu_PAD_GPIO_A_14_ctl,14); 
+                    },
+                name: "FUNCMAX")
+                .WithReservedBits(9, 23)     
+            ;
+            Registers.std_pu_PAD_GPIO_A_15_ctl.Define(this)
+                .WithFlag(0, FieldMode.Read|FieldMode.Write,name: "EN", writeCallback: ( _, value) => EN[15]=value)
+                .WithTag("DS", 1, 2)
+                .WithReservedBits(3, 2)
+                .WithTaggedFlag("PUE", 5)
+                .WithTaggedFlag("PUD", 6)
+                .WithEnumField<DoubleWordRegister, IOMode>(7, 2,     
+                writeCallback: (_, value) =>  {
+                    MUX[15]=selection((IOMode)value);
+                    UpdateStatus(Registers.std_pu_PAD_GPIO_A_15_ctl,15); 
+                    },
+                name: "FUNCMAX")
+                .WithReservedBits(9, 23)    
+            ;              
+        }
+        
+        private const int NumberOfGPIOs = 80;
+        private const int NumberofPadOutput = 15;
+        public const uint PadKeyUnlockValue = 0x2A6>>1;
+        private bool status = false; 
+        private uint[] MUX=new uint[16];
+        private bool[] EN = new bool[16];
+        private uint[] MUX_S=new uint[16];
+        private bool[] EN_S = new bool[16];
+        private const int GPIOPinsIndex = 16;
+        private const int FPGAPinsIndex = 32;
+        private const int AltPinsIndex = 48;
+        private const int DebugPinsIndex = 64;
+        public enum IOMode
+        {   
+            MainMode = 0, 
+            Fpga_pinMode = 1, 
+            AlternativeMode = 2, 
+            DebugMode = 3
+        }
+  
+        private enum Registers
+        {
+            pad_csr = 0x1000,
+            std_pu_PAD_GPIO_A_0_ctl = 0x1004,
+            std_pu_PAD_GPIO_A_1_ctl = 0x1008,
+            std_pu_PAD_GPIO_A_2_ctl = 0x100C,
+            std_pu_PAD_GPIO_A_3_ctl = 0x1010,
+            std_pu_PAD_GPIO_A_4_ctl = 0x1014,
+            std_pu_PAD_GPIO_A_5_ctl = 0x1018,
+            std_pu_PAD_GPIO_A_6_ctl = 0x101C,
+            std_pu_PAD_GPIO_A_7_ctl = 0x1020,
+            std_pu_PAD_GPIO_A_8_ctl = 0x1024,
+            std_pu_PAD_GPIO_A_9_ctl = 0x1028,
+            std_pu_PAD_GPIO_A_10_ctl = 0x102C ,
+            std_pu_PAD_GPIO_A_11_ctl = 0x1030,
+            std_pu_PAD_GPIO_A_12_ctl = 0x1034,
+            std_pu_PAD_GPIO_A_13_ctl = 0x1038,
+            std_pu_PAD_GPIO_A_14_ctl = 0x103C,
+            std_pu_PAD_GPIO_A_15_ctl = 0x1040
+        }
+    }
+}

--- a/src/Emulator/Peripherals/Peripherals/Miscellaneous/Virgo_pad.cs
+++ b/src/Emulator/Peripherals/Peripherals/Miscellaneous/Virgo_pad.cs
@@ -634,7 +634,7 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
           private void UpdateStatus(Registers reg , int i)
           {
             if (EN[i] != EN_S[i] || MUX[i] != MUX_S[i]) 
-                  status = false;        
+                status = false;        
           }
         private void PrepareRegisters()
         {          


### PR DESCRIPTION
1. Add support for Virgo pad .
2. Pad controller have 16 outputs (0-15)
3. Have 4 modes (main , fpga_gpio, ALT function and debug mode) and consists 16 inputs for
    each mode
   (a) Main function is in range (16-31)
   (b) FPGA_GPIO is in range (32-47)
   (c) ALT Function is in range (48-63)
  (d) Debug Mode is in range (64-80)
4. Shadow register functionality is also implemented and tested.
5. GPIO and FPGA_GPIO functionality is tested and link to test cases shared on confluence
    https://rapidsilicon.atlassian.net/l/cp/1rP0xwLL